### PR TITLE
Fix monitoring of ASHAbot

### DIFF
--- a/byoeb-v1/byoeb/Dockerfile
+++ b/byoeb-v1/byoeb/Dockerfile
@@ -27,4 +27,4 @@ RUN poetry install --no-root --no-interaction --no-ansi
 EXPOSE 8000
 
 # Command to run your FastAPI app
-CMD ["poetry", "run", "python3", "-m", "byoeb.chat_app.run:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["poetry", "run", "python3", "-m", "byoeb.chat_app.run", "--host", "0.0.0.0", "--port", "8000"]

--- a/byoeb-v1/byoeb/Dockerfile
+++ b/byoeb-v1/byoeb/Dockerfile
@@ -27,4 +27,4 @@ RUN poetry install --no-root --no-interaction --no-ansi
 EXPOSE 8000
 
 # Command to run your FastAPI app
-CMD ["poetry", "run", "uvicorn", "byoeb.chat_app.run:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["poetry", "run", "python3", "-m", "byoeb.chat_app.run:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/byoeb-v1/byoeb/byoeb/chat_app/run.py
+++ b/byoeb-v1/byoeb/byoeb/chat_app/run.py
@@ -65,23 +65,22 @@ app, mcp_app = create_apps()
 # Issue with multiple workers in FastAPI
 # https://github.com/encode/uvicorn/discussions/2450
 if __name__ == '__main__':
+    module_name = os.path.splitext(os.path.basename(__file__))[0]
     if os.getenv("APP_ENV") == "PROD":
         current_dir = os.path.dirname(os.path.abspath(__file__))
         log_config_path = os.path.join(current_dir, 'logging.yaml')
         log_config_path = os.path.normpath(log_config_path)
         log_config = None
-        module_name = os.path.splitext(os.path.basename(__file__))[0]
         with open(log_config_path, 'r') as file:
             log_config = yaml.safe_load(file)
         logging.config.dictConfig(log_config)
         logging.getLogger("azure.core.pipeline.policies.http_logging_policy").setLevel(logging.CRITICAL)
         uvicorn.run(
-            app,
+            f"{module_name}:app",
             host="0.0.0.0",
             port=8000
         )
     else:
-        module_name = os.path.splitext(os.path.basename(__file__))[0]
         print(module_name)
         uvicorn.run(
             f"{module_name}:app",

--- a/byoeb-v1/byoeb/byoeb/chat_app/run.py
+++ b/byoeb-v1/byoeb/byoeb/chat_app/run.py
@@ -65,7 +65,7 @@ app, mcp_app = create_apps()
 # Issue with multiple workers in FastAPI
 # https://github.com/encode/uvicorn/discussions/2450
 if __name__ == '__main__':
-    module_name = os.path.splitext(os.path.basename(__file__))[0]
+    module_name = "byoeb.chat_app.run"
     if os.getenv("APP_ENV") == "PROD":
         current_dir = os.path.dirname(os.path.abspath(__file__))
         log_config_path = os.path.join(current_dir, 'logging.yaml')


### PR DESCRIPTION
## Introduction
Uvicorn interferes with Azure AppInsights log delivery when fastapi wsgi object is directly passed to it. Prior to this change, Azure monitor dashboard under the Overview tab had empty charts and REST API request logs weren't being recorded.

## Attachments
**Overview** tab for the project on Azure Portal - charts are properly updated:
<img alt="image" src="https://github.com/user-attachments/assets/d0ed7958-9ee5-4666-9d6c-d50b9d165953" />

**Monitoring** → **Logs** tab for the project on Azure Portal - now shows request logs:
<img alt="image" src="https://github.com/user-attachments/assets/2ef4ce30-623b-4f7e-a5bb-ed55587fa573" />
