### PR TITLE
mcp: use stateless http to support horizontal scaling

### DIFF
--- a/byoeb-v1/byoeb/byoeb/chat_app/run.py
+++ b/byoeb-v1/byoeb/byoeb/chat_app/run.py
@@ -32,7 +32,7 @@ def create_apps():
     app.include_router(user_apis_router)
     app.include_router(admin_apis_router)
 
-    mcp = FastMCP()
+    mcp = FastMCP(stateless_http=True)
     health_mcps_router(mcp)
     chat_mcps_router(mcp)
     user_mcps_router(mcp)


### PR DESCRIPTION
## Introduction
(not to be confused with "streamable-http", which is the transport method we selected for the mcp server).

Stateful Streamable HTTP requires sticky sessions. On Azure App Service with multiple instances, requests hit different nodes so session lookups fail due to the following error:
```
[5412] [5412] Connecting to remote server: https://byoebapptest-hdfhegcgceg9c5ah.southindia-01.azurewebsites.net/mcp?phone_number=916364845304
[5412] Using transport strategy: http-first
[5412] Connection error: Error: Error POSTing to endpoint (HTTP 400): Bad Request: No valid session ID provided
    at StreamableHTTPClientTransport.send (file:///C:/Users/notmu/AppData/Local/npm-cache/_npx/705d23756ff7dacc/node_modules/mcp-remote/dist/chunk-AKJME7CQ.js:13461:15)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Client.notification (file:///C:/Users/notmu/AppData/Local/npm-cache/_npx/705d23756ff7dacc/node_modules/mcp-remote/dist/chunk-AKJME7CQ.js:11579:5)
    at async Client.connect (file:///C:/Users/notmu/AppData/Local/npm-cache/_npx/705d23756ff7dacc/node_modules/mcp-remote/dist/chunk-AKJME7CQ.js:11690:7)
    at async connectToRemoteServer (file:///C:/Users/notmu/AppData/Local/npm-cache/_npx/705d23756ff7dacc/node_modules/mcp-remote/dist/chunk-AKJME7CQ.js:13843:9)
    at async runProxy (file:///C:/Users/notmu/AppData/Local/npm-cache/_npx/705d23756ff7dacc/node_modules/mcp-remote/dist/proxy.js:141:29)
[5412] Fatal error: Error: Error POSTing to endpoint (HTTP 400): Bad Request: No valid session ID provided
    at StreamableHTTPClientTransport.send (file:///C:/Users/notmu/AppData/Local/npm-cache/_npx/705d23756ff7dacc/node_modules/mcp-remote/dist/chunk-AKJME7CQ.js:13461:15)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Client.notification (file:///C:/Users/notmu/AppData/Local/npm-cache/_npx/705d23756ff7dacc/node_modules/mcp-remote/dist/chunk-AKJME7CQ.js:11579:5)
    at async Client.connect (file:///C:/Users/notmu/AppData/Local/npm-cache/_npx/705d23756ff7dacc/node_modules/mcp-remote/dist/chunk-AKJME7CQ.js:11690:7)
    at async connectToRemoteServer (file:///C:/Users/notmu/AppData/Local/npm-cache/_npx/705d23756ff7dacc/node_modules/mcp-remote/dist/chunk-AKJME7CQ.js:13843:9)
    at async runProxy (file:///C:/Users/notmu/AppData/Local/npm-cache/_npx/705d23756ff7dacc/node_modules/mcp-remote/dist/proxy.js:141:29)
```

`stateless_http=True` makes each request self-contained - every request is a fresh request and there is no concept of states anymore. This works well for our use case - `/mcp?phone_number=91xxxxxxxxxx` is sufficient to lookup user on ASHAbot's end, and conversation state / "memory" is entirely managed by mcp clients.