### PR TITLE
ci: include "staging" branch

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,9 +2,9 @@ name: CI - MongoDB Tests
 
 on:
   push:
-    branches: [ a4i/main ]
+    branches: [ a4i/main, staging ]
   pull_request:
-    branches: [ a4i/main ]
+    branches: [ a4i/main, staging ]
 
 jobs:
   tests:


### PR DESCRIPTION
## Introduction
CI is configured to run on only `a4i/main` branch. Existing PRs that target `staging` are not covered by CI. This change includes `staging` branch to the workflow file alongside `a4i/main`.