### PR TITLE
/receive: fix 4xx, 5xx errors during message type validation

### DIFF
--- a/byoeb-v1/byoeb-core/byoeb_core/models/byoeb/response.py
+++ b/byoeb-v1/byoeb-core/byoeb_core/models/byoeb/response.py
@@ -8,7 +8,6 @@ class ByoebStatusCodes(Enum):
 
     Attributes:
         OK (int): The status code for a successful request.
-        ACCEPTED (int): The status code for an accepted request that will not be processed further.
         BAD_REQUEST (int): The status code for a bad request.
         UNAUTHORIZED (int): The status code for an unauthorized request.
         FORBIDDEN (int): The status code for a forbidden request.
@@ -16,7 +15,6 @@ class ByoebStatusCodes(Enum):
         INTERNAL_SERVER_ERROR (int): The status code for an internal server error.
     """
     OK = 200
-    ACCEPTED = 202
     BAD_REQUEST = 400
     UNAUTHORIZED = 401
     FORBIDDEN = 403

--- a/byoeb-v1/byoeb-core/byoeb_core/models/byoeb/response.py
+++ b/byoeb-v1/byoeb-core/byoeb_core/models/byoeb/response.py
@@ -8,6 +8,7 @@ class ByoebStatusCodes(Enum):
 
     Attributes:
         OK (int): The status code for a successful request.
+        ACCEPTED (int): The status code for an accepted request that will not be processed further.
         BAD_REQUEST (int): The status code for a bad request.
         UNAUTHORIZED (int): The status code for an unauthorized request.
         FORBIDDEN (int): The status code for a forbidden request.
@@ -15,6 +16,7 @@ class ByoebStatusCodes(Enum):
         INTERNAL_SERVER_ERROR (int): The status code for an internal server error.
     """
     OK = 200
+    ACCEPTED = 202
     BAD_REQUEST = 400
     UNAUTHORIZED = 401
     FORBIDDEN = 403

--- a/byoeb-v1/byoeb-integrations/byoeb_integrations/channel/tests/test_async_whatsapp.py
+++ b/byoeb-v1/byoeb-integrations/byoeb_integrations/channel/tests/test_async_whatsapp.py
@@ -442,6 +442,12 @@ def test_status_message():
     assert byoeb_message.message_id == "wamid.HBgMOTE4ODM3NzAxODI4FQIAERgSQjM1RjY0M0QyMkU4OUU3OTc3AA=="
     assert message_type == "status"
 
+def test_bogus_message():
+    message = '{"object": true}'
+    is_wa, message_type = wa_validate.validate_whatsapp_message(message)
+    assert is_wa is False
+    assert message_type is None
+
 import byoeb_integrations.channel.whatsapp.request_payload as wa_request_payload
 from byoeb_core.models.byoeb.message_context import ByoebMessageContext
 def test_text_request_payload():

--- a/byoeb-v1/byoeb-integrations/byoeb_integrations/channel/whatsapp/validate_message.py
+++ b/byoeb-v1/byoeb-integrations/byoeb_integrations/channel/whatsapp/validate_message.py
@@ -1,8 +1,6 @@
 import json
-import logging
 import byoeb_core.models.whatsapp.incoming as incoming_message
 
-logger = logging.getLogger(__name__)
 def validate_regular_message(original_message):
     if isinstance(original_message, str):
         original_message = json.loads(original_message)
@@ -12,8 +10,7 @@ def validate_regular_message(original_message):
             return True
         if regular_message.entry[0].changes[0].value.messages[0].type == "audio":
             return True
-    except Exception as e:
-        logger.error(f"Regular message validation error: {str(e)}")
+    except Exception:
         return False
     return False
 
@@ -24,8 +21,7 @@ def validate_template_message(original_message):
         template_message = incoming_message.WhatsAppTemplateMessageBody.model_validate(original_message)
         if template_message.entry[0].changes[0].value.messages[0].type == "button":
             return True
-    except Exception as e:
-        logger.error(f"Template message validation error: {str(e)}")
+    except Exception:
         return False
     return False
 
@@ -36,8 +32,7 @@ def validate_interactive_message(original_message):
         interactive_message = incoming_message.WhatsAppInteractiveMessageBody.model_validate(original_message)
         if interactive_message.entry[0].changes[0].value.messages[0].type == "interactive":
             return True
-    except Exception as e:
-        logger.error(f"Interactive message validation error: {str(e)}")
+    except Exception:
         return False
     return False
 
@@ -48,8 +43,7 @@ def validate_status_message(original_message):
         status_message = incoming_message.WhatsAppStatusMessageBody.model_validate(original_message)
         if status_message.entry[0].changes[0].value.statuses is not None:
             return True
-    except Exception as e:
-        logger.error(f"Status message validation error: {str(e)}")
+    except Exception:
         return False
     return False
 

--- a/byoeb-v1/byoeb-integrations/byoeb_integrations/channel/whatsapp/validate_message.py
+++ b/byoeb-v1/byoeb-integrations/byoeb_integrations/channel/whatsapp/validate_message.py
@@ -32,7 +32,6 @@ def validate_template_message(original_message):
 def validate_interactive_message(original_message):
     if isinstance(original_message, str):
         original_message = json.loads(original_message)
-    interactive_message = incoming_message.WhatsAppInteractiveMessageBody.model_validate(original_message)
     try:
         interactive_message = incoming_message.WhatsAppInteractiveMessageBody.model_validate(original_message)
         if interactive_message.entry[0].changes[0].value.messages[0].type == "interactive":

--- a/byoeb-v1/byoeb/byoeb/handler/message_producer.py
+++ b/byoeb-v1/byoeb/byoeb/handler/message_producer.py
@@ -54,7 +54,7 @@ class QueueProducerHandler:
 
         if message_type is None:
             print(f"[handle] ↳ branch: unsupported message type")
-            return ByoebResponseModel(status_code=ByoebStatusCodes.ACCEPTED, message="unsupported message type")
+            return ByoebResponseModel(status_code=ByoebStatusCodes.OK, message="unsupported message type")
 
         if message_type == "status":
             print("[handle] ↳ branch: status → return OK('status update')")

--- a/byoeb-v1/byoeb/byoeb/handler/message_producer.py
+++ b/byoeb-v1/byoeb/byoeb/handler/message_producer.py
@@ -1,9 +1,12 @@
+import json
 import logging
 import traceback
+import byoeb_core.models.whatsapp.incoming as incoming_message
 import byoeb_integrations.channel.whatsapp.validate_message as wa_validator
 from byoeb.services.databases.mongo_db.message_db import MessageMongoDBService
 from typing import Any
 from byoeb.factory import QueueProducerFactory
+from byoeb.chat_app.configuration.dependency_setup import app_insights_logger
 from byoeb.services.chat.message_producer import MessageProducerService
 from byoeb_core.models.byoeb.response import ByoebResponseModel, ByoebStatusCodes
 
@@ -55,9 +58,17 @@ class QueueProducerHandler:
 
         if message_type == "status":
             print("[handle] ↳ branch: status → return OK('status update')")
+            status_message = incoming_message.WhatsAppStatusMessageBody.model_validate(message)
+            status = status_message.entry[0].changes[0].value.statuses[0].model_dump()
+            app_insights_logger.add_log(event_name="wa_transmission_status", details={
+                "id": status["id"],
+                "status": status["status"],
+                "timestamp": str(status["timestamp"]),
+                "errors": json.dumps(status["errors"] or [])
+            })
             return ByoebResponseModel(
                 status_code=ByoebStatusCodes.OK,
-                message="status update"
+                message={"id": status["id"], "status": status["status"]}
             )
 
         if not channel:

--- a/byoeb-v1/byoeb/byoeb/handler/message_producer.py
+++ b/byoeb-v1/byoeb/byoeb/handler/message_producer.py
@@ -51,7 +51,7 @@ class QueueProducerHandler:
 
         if message_type is None:
             print(f"[handle] ↳ branch: unsupported message type")
-            return ByoebResponseModel(status_code=ByoebStatusCodes.OK)
+            return ByoebResponseModel(status_code=ByoebStatusCodes.ACCEPTED, message="unsupported message type")
 
         if message_type == "status":
             print("[handle] ↳ branch: status → return OK('status update')")

--- a/byoeb-v1/byoeb/byoeb/handler/message_producer.py
+++ b/byoeb-v1/byoeb/byoeb/handler/message_producer.py
@@ -49,6 +49,10 @@ class QueueProducerHandler:
         channel, message_type = await self.__validate_channel_and_get_message_type(message)
         print(f"[handle] ← __validate...  out channel={channel}, message_type={message_type}")
 
+        if message_type is None:
+            print(f"[handle] ↳ branch: unsupported message type")
+            return ByoebResponseModel(status_code=ByoebStatusCodes.OK)
+
         if message_type == "status":
             print("[handle] ↳ branch: status → return OK('status update')")
             return ByoebResponseModel(

--- a/byoeb-v1/byoeb/byoeb/handler/message_producer.py
+++ b/byoeb-v1/byoeb/byoeb/handler/message_producer.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import traceback
-import byoeb_core.models.whatsapp.incoming as incoming_message
 import byoeb_integrations.channel.whatsapp.validate_message as wa_validator
 from byoeb.services.databases.mongo_db.message_db import MessageMongoDBService
 from typing import Any
@@ -58,8 +57,7 @@ class QueueProducerHandler:
 
         if message_type == "status":
             print("[handle] ↳ branch: status → return OK('status update')")
-            status_message = incoming_message.WhatsAppStatusMessageBody.model_validate(message)
-            status = status_message.entry[0].changes[0].value.statuses[0].model_dump()
+            status = message["entry"][0]["changes"][0]["value"]["statuses"][0]
             app_insights_logger.add_log(event_name="wa_transmission_status", details={
                 "id": status["id"],
                 "status": status["status"],
@@ -106,4 +104,3 @@ class QueueProducerHandler:
             status_code=ByoebStatusCodes.OK,
             message=response
         )
-        


### PR DESCRIPTION
## Introduction
Unsupported WhatsApp message inputs (e.g., Location, Image, Audio) return a 400. This caused excessive noise in failure logs without adding diagnostic value.

## Changes
Adjusted message producer logic:
- Unsupported message types now return 200 instead of 4xx
- Fixed certain unexpected messages returning a 500 due to prematurely validating "interactive" message types. New test case `test_bogus_message` confirms malformed messages are handled gracefully (is_wa=False, message_type=None)
- Added a custom telemetry event `wa_transmission_status` that logs WhatsApp message statuses for debugging and retrieval

## Steps to test
1. Update byoeb-integrations/pyproject.toml:
   ```diff
   - byoeb-core = { git = "https://github.com/A4i-tech/byoeb.git", rev = "a4i/main", subdirectory = "byoeb-v1/byoeb-core" }
   + byoeb-core = {path = "../byoeb-core"}
   ```
2. Update byoeb/pyproject.toml:
   ```diff
   - byoeb-integrations = {git = "https://github.com/A4i-tech/byoeb.git", branch = "a4i/main", subdirectory = "byoeb-v1/byoeb-integrations"}
   + byoeb-integrations = {path = "../byoeb-integrations"}
   ```
3. Run chat app (`poetry run python3 byoeb/chat_app/run.py`)
4. Test /receive endpoint with sample payloads:
   ```sh
   # before: HTTP/1.1 400 Bad Request
   #  after: HTTP/1.1 202 Accepted "unsupported message type"
   curl -v -X POST "http://127.0.0.1:5000/receive" \
       -H "Content-Type: application/json" \
       -d '{"object": "whatsapp_business_account", "entry": [{"id": "11111", "changes": [{"value": {"messaging_product": "whatsapp", "metadata": {"display_phone_number": "911111111111", "phone_number_id": "1811111111"}, "contacts": [{"profile": {"name": "Muqsit"}, "wa_id": "911111111111"}], "messages": [{"from": "911111111111", "id": "wamid.xxxx", "timestamp": "1761717747", "type": "reaction", "reaction": {"message_id": "wamid.xxxx==", "emoji": "\ud83d\ude2e"}}]}, "field": "messages"}]}]}' \
       -i
   ```