### PR TITLE
poetry: fix jinja2 dep not found for /asha_logs, /experiment endpoints

### DIFF
--- a/byoeb-v1/byoeb/byoeb/apis/admin.py
+++ b/byoeb-v1/byoeb/byoeb/apis/admin.py
@@ -1,27 +1,20 @@
-import logging
 import os
-import subprocess
-import pytz
 from byoeb.models.experiment import QueryInput
 from io import BytesIO
-from azure.identity import DefaultAzureCredential
 from datetime import datetime
 from fastapi import APIRouter, Request
-from croniter import croniter
 from fastapi.responses import JSONResponse
 from fastapi import Form, Request
-from fastapi.responses import HTMLResponse, FileResponse, StreamingResponse
+from fastapi.responses import HTMLResponse, StreamingResponse
 from fastapi.templating import Jinja2Templates
 from fastapi.responses import StreamingResponse
 from byoeb.background_jobs.daily_logs.asha_logs import fetch_daily_logs
-from byoeb_integrations.media_storage.azure.async_azure_blob_storage import AsyncAzureBlobStorage
 from byoeb.services.admin.message_process import process_message, clear_history
 from byoeb.chat_app.configuration.dependency_setup import media_storage
 
 REGISTER_API_NAME = 'admin_apis'
 
 admin_apis_router = APIRouter()
-_logger = logging.getLogger(REGISTER_API_NAME)
 
 current_dir = os.path.dirname(os.path.abspath(__file__))
 jobs_path = os.path.join(current_dir, '..', 'background_jobs')

--- a/byoeb-v1/byoeb/pyproject.toml
+++ b/byoeb-v1/byoeb/pyproject.toml
@@ -20,6 +20,7 @@ uvicorn = "^0.35.0"
 python-dotenv = "^1.1.1"
 fastmcp = "^2.12.3"
 apscheduler = "^3.11.0"
+jinja2 = "^3.1.6"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.4.1"


### PR DESCRIPTION
## Introduction
Jinja2 should have been explicitly stated as requirement in our pyproject.toml. But we were utilizing `notebook` a "jumbo" library that coincidentally used a dependency (`nbconvert`) that required `jinja2`. Now that we've removed the `notebook` dependency (unused), we no longer have Jinja2 either.

This was verified by running `!pip install notebook` and then `!pip show jinja2` in Colab:
```
Name: Jinja2
Version: 3.1.6
Summary: A very fast and expressive template engine.
Home-page: 
Author: 
Author-email: 
License: 
Location: /usr/local/lib/python3.12/dist-packages
Requires: MarkupSafe
Required-by: altair, bokeh, branca, distributed, Flask, folium, gradio, jupyter_server, nbconvert, notebook, osqp, rpy2, spacy, Sphinx, torch
```

## Tests
A pre-staging deployment `byoeb-fix-unmet-deps` is successfully deployed and uses this branch (`fix-unmet-deps`):
- https://byoeb-fix-unmet-deps.onrender.com/asha_logs
- https://byoeb-fix-unmet-deps.onrender.com/experiment

## Relevant PRs
- https://github.com/A4i-tech/byoeb/pull/19 has a "Watching deployment" step to ensure failures in staging deployments cause failure in the deployment job. Right now, staging build is marked 'Failed' on Render and we do not know of deployment's success unless we explicitly visit the Render dashboard.
   <img alt="image" src="https://github.com/user-attachments/assets/5f6045af-40af-4405-a3d3-e0f3eb70737c" />