### PR TITLE
kb-app: rebuild store as the first step

### DIFF
--- a/byoeb-v1/byoeb-core/byoeb_core/vector_stores/base.py
+++ b/byoeb-v1/byoeb-core/byoeb_core/vector_stores/base.py
@@ -73,9 +73,9 @@ class BaseVectorStore(ABC):
         **kwargs
     ) -> Any:
         return NotImplementedError
-    
+
     @abstractmethod
-    def delete_store(self):
+    def rebuild_store(self):
         pass
 
 

--- a/byoeb-v1/byoeb-integrations/byoeb_integrations/vector_stores/azure_vector_search/azure_vector_search.py
+++ b/byoeb-v1/byoeb-integrations/byoeb_integrations/vector_stores/azure_vector_search/azure_vector_search.py
@@ -2,13 +2,30 @@ import asyncio
 import hashlib
 import logging
 from enum import Enum
-from typing import List
+from typing import List, Optional
 from tqdm.asyncio import tqdm
 from datetime import datetime, timezone
+from byoeb.constants.user_enums import LanguageCode
 from byoeb_core.vector_stores.base import BaseVectorStore
 from byoeb_core.llms.base import BaseLLM
 from azure.search.documents import SearchClient, SearchIndexingBufferedSender
 from azure.search.documents.indexes import SearchIndexClient
+from azure.search.documents.indexes import SearchIndexClient
+from azure.search.documents.indexes.models import (
+    SearchIndex,
+    SearchField,
+    SimpleField,
+    SearchableField,
+    ComplexField,
+    SearchFieldDataType,
+    VectorSearch,
+    HnswAlgorithmConfiguration,
+    HnswParameters,
+    VectorSearchAlgorithmKind,
+    VectorSearchAlgorithmMetric,
+    VectorSearchProfile,
+    BM25SimilarityAlgorithm,
+)
 from azure.search.documents.models import VectorizableTextQuery, IndexAction
 from byoeb_core.models.vector_stores.azure.azure_search import AzureSearchNode, Metadata
 from byoeb_integrations.vector_stores.related_questions import aget_related_questions
@@ -31,8 +48,8 @@ class AzureVectorStore(BaseVectorStore):
         service_name: str,
         index_name: str,
         embedding_function,
-        api_key: str = None,
-        credential = None,
+        api_key: Optional[str] = None,
+        credential = None
     ):
         if not service_name:
             raise ValueError("service_name is required")
@@ -315,5 +332,41 @@ class AzureVectorStore(BaseVectorStore):
             chunk_list.append(chunk)
         return chunk_list
 
-    def delete_store(self):
+    def rebuild_store(self):
         self.search_index_client.delete_index(self.__index_name)
+        self.search_index_client.create_index(SearchIndex(
+            name=self.__index_name,
+            fields=[
+                SimpleField(name="id", type=SearchFieldDataType.String, key=True, searchable=False, filterable=True, retrievable=True, stored=True, sortable=True, facetable=False),
+                SearchableField(name="text", type=SearchFieldDataType.String, analyzer_name="standard.lucene", searchable=True, filterable=False, retrievable=True, stored=True, sortable=False, facetable=False),
+                SearchField(
+                    name="text_vector_3072",
+                    type=SearchFieldDataType.Collection(SearchFieldDataType.Single),
+                    searchable=True,
+                    filterable=False,
+                    retrievable=False,
+                    stored=True,
+                    sortable=False,
+                    facetable=False,
+                    vector_search_dimensions=3072,
+                    vector_search_profile_name="default-vector-profile"
+                ),
+                ComplexField(name="metadata", fields=[
+                    SimpleField(name="source", type=SearchFieldDataType.String, searchable=False, filterable=True, retrievable=True, stored=True, sortable=True, facetable=True),
+                    SimpleField(name="creation_timestamp", type=SearchFieldDataType.String, searchable=False, filterable=True, retrievable=True, stored=True, sortable=True, facetable=False),
+                    SimpleField(name="update_timestamp", type=SearchFieldDataType.String, searchable=False, filterable=True, retrievable=True, stored=True, sortable=True, facetable=False),
+                ]),
+                ComplexField(name="related_questions", fields=[
+                    SearchField(name=lang.value, type=SearchFieldDataType.Collection(SearchFieldDataType.String), searchable=False, filterable=False, retrievable=True, stored=True, sortable=False, facetable=False)
+                    for lang in LanguageCode
+                ]),
+            ],
+            similarity=BM25SimilarityAlgorithm(),
+            vector_search=VectorSearch(algorithms=[
+                HnswAlgorithmConfiguration(name="default-hnsw-config", kind=VectorSearchAlgorithmKind.HNSW, parameters=HnswParameters(
+                    metric=VectorSearchAlgorithmMetric.COSINE, m=4, ef_construction=400, ef_search=500
+                ))
+            ], profiles=[
+                VectorSearchProfile(name="default-vector-profile", algorithm_configuration_name="default-hnsw-config")
+            ])
+        ))

--- a/byoeb-v1/byoeb-integrations/byoeb_integrations/vector_stores/azure_vector_search/azure_vector_search.py
+++ b/byoeb-v1/byoeb-integrations/byoeb_integrations/vector_stores/azure_vector_search/azure_vector_search.py
@@ -5,7 +5,6 @@ from enum import Enum
 from typing import List, Optional
 from tqdm.asyncio import tqdm
 from datetime import datetime, timezone
-from byoeb.constants.user_enums import LanguageCode
 from byoeb_core.vector_stores.base import BaseVectorStore
 from byoeb_core.llms.base import BaseLLM
 from azure.search.documents import SearchClient, SearchIndexingBufferedSender
@@ -357,8 +356,8 @@ class AzureVectorStore(BaseVectorStore):
                     SimpleField(name="update_timestamp", type=SearchFieldDataType.String, searchable=False, filterable=True, retrievable=True, stored=True, sortable=True, facetable=False),
                 ]),
                 ComplexField(name="related_questions", fields=[
-                    SearchField(name=lang.value, type=SearchFieldDataType.Collection(SearchFieldDataType.String), searchable=False, filterable=False, retrievable=True, stored=True, sortable=False, facetable=False)
-                    for lang in LanguageCode
+                    SearchField(name=lang, type=SearchFieldDataType.Collection(SearchFieldDataType.String), searchable=False, filterable=False, retrievable=True, stored=True, sortable=False, facetable=False)
+                    for lang in ["en", "hi", "mr", "te"]
                 ]),
             ],
             similarity=BM25SimilarityAlgorithm(),

--- a/byoeb-v1/byoeb-integrations/byoeb_integrations/vector_stores/chroma/base.py
+++ b/byoeb-v1/byoeb-integrations/byoeb_integrations/vector_stores/chroma/base.py
@@ -298,8 +298,8 @@ class ChromaDBVectorStore(BaseVectorStore):
             name=self.__collection_name,
             embedding_function=self.__embedding_function
         )
-    
-    def delete_store(self):
+
+    def rebuild_store(self):
         """
         Delete the entire store and recreate the collection.
         Similar to Azure Vector Store pattern - always use fresh collection reference.

--- a/byoeb-v1/byoeb-integrations/byoeb_integrations/vector_stores/llama_index/llama_index_chroma_store.py
+++ b/byoeb-v1/byoeb-integrations/byoeb_integrations/vector_stores/llama_index/llama_index_chroma_store.py
@@ -133,9 +133,9 @@ class LlamaIndexChromaDBStore(BaseVectorStore):
             )
             chunk_list.append(chunk)
         return chunk_list
-    
-    def delete_store(self):
+
+    def rebuild_store(self):
         if self.vector_store_index is not None:
-            self.chromadb.delete_store()
-        self.vector_store_index = None
-    
+            self.chromadb.rebuild_store()
+            self.vector_store_index = None
+            self.__get_or_create_store()

--- a/byoeb-v1/byoeb-integrations/byoeb_integrations/vector_stores/tests/test_vector_store_azure_vector_search.py
+++ b/byoeb-v1/byoeb-integrations/byoeb_integrations/vector_stores/tests/test_vector_store_azure_vector_search.py
@@ -184,11 +184,11 @@ async def test_azure_vector_search_query(embedding_fn_stub):
         end_time = datetime.now().timestamp()
         print("Execution Time: ", end_time - start_time)
 
-def test_azure_vector_search_delete(embedding_fn_stub):
+def test_azure_vector_search_rebuild(embedding_fn_stub):
     azure_vector_search = AzureVectorStore(
         SERVICE_NAME,
         INDEX_NAME,
         embedding_fn_stub,
         credential=DefaultAzureCredential()
     )
-    azure_vector_search.delete_store()
+    azure_vector_search.rebuild_store()

--- a/byoeb-v1/byoeb-integrations/byoeb_integrations/vector_stores/tests/test_vector_store_chroma.py
+++ b/byoeb-v1/byoeb-integrations/byoeb_integrations/vector_stores/tests/test_vector_store_chroma.py
@@ -26,7 +26,7 @@ def test_chroma_vector_store_ops(tmp_path):
 
     responses: List[Chunk] = chromavs.retrieve_top_k_chunks("hello", 1)
     assert responses and responses[0].text == "hello"
-    chromavs.delete_store()
+    chromavs.rebuild_store()
 
 def test_llama_index_chroma_vector_store_ops(tmp_path):
     embed_model = MockEmbedding(embed_dim=4)
@@ -38,7 +38,7 @@ def test_llama_index_chroma_vector_store_ops(tmp_path):
     assert responses and responses[0].text == "hello"
 
     count_before = chromavs.collection.count()
-    chromavs.delete_store()
+    chromavs.rebuild_store()
     chromavs.add_chunks(["hello", "world"], [{"a": 1}, {"b": 2}], ["1", "2"])
     count_after = chromavs.collection.count()
     assert count_after == count_before

--- a/byoeb-v1/byoeb/byoeb/scripts/knowledge_base/create_kb.py
+++ b/byoeb-v1/byoeb/byoeb/scripts/knowledge_base/create_kb.py
@@ -37,7 +37,7 @@ prefix_updated_documents = "expert_update_documents"
 
 ## Azure Vector Search properties
 endpoint="byoebstage-search"
-index_name="byoebstage-doc-index-test-muqsit"
+index_name="byoebstage-doc-index-latest"
 key=os.getenv("AZURE_SEARCH_API_KEY")
 if key is None:
     key=DefaultAzureCredential()

--- a/byoeb-v1/byoeb/byoeb/scripts/knowledge_base/create_kb.py
+++ b/byoeb-v1/byoeb/byoeb/scripts/knowledge_base/create_kb.py
@@ -6,11 +6,10 @@ import asyncio
 import logging
 import hashlib
 import xml.etree.ElementTree as ET
-from tenacity import retry, stop_after_attempt, wait_exponential, RetryError
-from byoeb.kb_app.configuration.config import prompt_config
+from pathlib import Path
+from tenacity import retry, stop_after_attempt, wait_exponential
 from byoeb.kb_app.configuration.dependency_setup import (
     amedia_storage,
-    vector_store,
     azure_openai_embed,
     llm_client
 )
@@ -18,31 +17,36 @@ from azure.identity import DefaultAzureCredential
 from typing import List
 from datetime import datetime, timezone
 from byoeb_core.data_parser.llama_index_text_parser import LLamaIndexTextParser, LLamaIndexTextSplitterType
-from byoeb_core.models.media_storage.file_data import FileMetadata, FileData
-from enum import Enum
+from byoeb_core.models.media_storage.file_data import FileData
 from typing import List
 from tqdm.asyncio import tqdm
 from datetime import datetime
-from byoeb_core.vector_stores.base import BaseVectorStore
 from byoeb_core.llms.base import BaseLLM
-from azure.search.documents import SearchClient, SearchIndexingBufferedSender
-from azure.search.documents.indexes import SearchIndexClient
-from azure.search.documents.models import VectorizableTextQuery, IndexAction
-from byoeb_core.models.vector_stores.azure.azure_search import AzureSearchNode, Metadata
-from byoeb_integrations.vector_stores.related_questions import aget_related_questions
-from byoeb_core.models.vector_stores.chunk import Chunk, Chunk_metadata
+from azure.search.documents import  SearchIndexingBufferedSender
+from azure.search.documents.models import IndexAction
+from byoeb.scripts.knowledge_base.upload_from_blob_to_azure_search_index import abulk_download_files
 
 logger = logging.getLogger("kb_service")
+KB_DIR = Path(__file__).resolve().parent
+FAILURES_PATH = KB_DIR / "failures.txt"
+STUCK_CHUNK_PATH = KB_DIR / "stuck_chunk.txt"
+CHECKPOINT_PATH = KB_DIR / "temp.pkl"
 prefix_raw_documents = "raw_documents"
 prefix_raw_faq_documents = "raw_documents/FAQ"
 prefix_updated_documents = "expert_update_documents"
 
 ## Azure Vector Search properties
 endpoint="byoebstage-search"
-index_name="byoebstage-doc-index-latest"
+index_name="byoebstage-doc-index-test-muqsit"
 key=os.getenv("AZURE_SEARCH_API_KEY")
 if key is None:
     key=DefaultAzureCredential()
+    
+def fails(error: IndexAction):
+        print("Failed to upload document")
+        with open(FAILURES_PATH, "a") as file:
+            file.write(f"Action type: {error.action_type}\n")
+            file.write(f"Properties: {error.additional_properties}\n")
 search_index_client = SearchIndexingBufferedSender(endpoint=endpoint, index_name=index_name, credential=key,on_error=fails)
 
 @retry(
@@ -391,7 +395,7 @@ async def agenerate_related_questions(
         if count > 13:
             print("Stuck in loop for 13 iterations")
             print(pairs_content)
-            with open("/home/rash598/Khushi/byoeb/byoeb-v1/byoeb/byoeb/scripts/knowledge_base/stuck_chunk.txt", "a") as file:
+            with open(STUCK_CHUNK_PATH, "a") as file:
                 print(f"Stuck in loop for {count} iterations")
                 file.write(f"{data_chunk}\n")
                 file.write(f"{pairs_content}\n")
@@ -480,7 +484,7 @@ async def agenerate_qas(
         if count > 13:
             print("Stuck in loop for 13 iterations")
             print(pairs_content)
-            with open("/home/rash598/Khushi/byoeb/byoeb-v1/byoeb/byoeb/scripts/knowledge_base/stuck_chunk.txt", "a") as file:
+            with open(STUCK_CHUNK_PATH, "a") as file:
                 print(f"Stuck in loop for {count} iterations")
                 file.write(f"{data_chunk}\n")
                 file.write(f"{pairs_content}\n")
@@ -720,13 +724,12 @@ async def prepare_azure_nodes(
     llm_client: BaseLLM = None
 ):
     documents = []
-    pkl_path = "/home/rash598/Khushi/byoeb/byoeb-v1/byoeb/byoeb/scripts/knowledge_base/temp.pkl"
     try:
-        with open(pkl_path, "rb") as file:
+        with open(CHECKPOINT_PATH, "rb") as file:
             documents = pickle.load(file)
     except:
         documents = []
-        with open(pkl_path, "wb") as file:
+        with open(CHECKPOINT_PATH, "wb") as file:
             pickle.dump(documents, file)
         print(f"Created checkpoint file")
     start = len(documents)
@@ -757,7 +760,7 @@ async def prepare_azure_nodes(
             if curr == checkpoint:
                 curr = 0
                 print(f"Saving checkpoint... {i+batch_size}/{len(data_chunks)}")
-                with open(pkl_path, "wb") as file:
+                with open(CHECKPOINT_PATH, "wb") as file:
                     pickle.dump(documents, file)
             curr += 1
             time.sleep(0.5)
@@ -766,7 +769,7 @@ async def prepare_azure_nodes(
             print(e)
             raise e
     print(f"Saving checkpoint...")
-    with open(pkl_path, "wb") as file:
+    with open(CHECKPOINT_PATH, "wb") as file:
         pickle.dump(documents, file)
     return documents
 
@@ -780,7 +783,7 @@ async def aget_files_from_blob_store():
     
 def fails(error: IndexAction):
         print("Failed to upload document")
-        with open("/home/rash598/Khushi/byoeb/byoeb-v1/byoeb/byoeb/scripts/knowledge_base/failures.txt", "a") as file:
+        with open(FAILURES_PATH, "a") as file:
             file.write(f"Action type: {error.action_type}\n")
             file.write(f"Properties: {error.additional_properties}\n")
             

--- a/byoeb-v1/byoeb/byoeb/scripts/knowledge_base/upload_from_blob_to_azure_search_index.py
+++ b/byoeb-v1/byoeb/byoeb/scripts/knowledge_base/upload_from_blob_to_azure_search_index.py
@@ -127,9 +127,6 @@ async def abulk_download_files(
                 files_data.append(response)
     return files_data
 
-def delete_kb():
-    vector_store.delete_store()
-
 async def main():
     await create_kb_from_blob_store()
     await amedia_storage._close()

--- a/byoeb-v1/byoeb/byoeb/scripts/knowledge_base/upload_to_blob.py
+++ b/byoeb-v1/byoeb/byoeb/scripts/knowledge_base/upload_to_blob.py
@@ -1,30 +1,34 @@
-import os
 import asyncio
+from pathlib import Path
 from tqdm.asyncio import tqdm
-from azure.identity import DefaultAzureCredential
 from byoeb_integrations.media_storage.azure.async_azure_blob_storage import AsyncAzureBlobStorage
-from glob import glob
 from byoeb.kb_app.configuration.dependency_setup import amedia_storage
 
+KB_DIR = Path(__file__).resolve().parent
+UPDATE_DOCUMENTS_DIR = KB_DIR.parents[2] / "update_documents"
+DEFAULT_UPLOAD_FILE = KB_DIR / "laado_scheme.txt"
+
 async def upload_file_to_blob(media_storage: AsyncAzureBlobStorage, file_path, folder_name="raw_documents"):
-    blob_file_name = f"{folder_name}/{os.path.basename(file_path)}"
+    file_path = Path(file_path)
+    blob_file_name = f"{folder_name}/{file_path.name}"
     await media_storage.aupload_file(  # Ensure this method exists
-        file_path=file_path,
+        file_path=str(file_path),
         file_name=blob_file_name
     )
     
 async def upload_folder_to_blob(media_storage: AsyncAzureBlobStorage, folder_path):
-    txt_file_paths = glob(os.path.join(folder_path, "*.txt"))
+    folder_path = Path(folder_path)
+    txt_file_paths = list(folder_path.glob("*.txt"))
 
     # Run uploads concurrently for better performance
-    await asyncio.gather(*(upload_file(media_storage, file) for file in tqdm(txt_file_paths, desc="Uploading files")))
+    await asyncio.gather(*(upload_file_to_blob(media_storage, file) for file in tqdm(txt_file_paths, desc="Uploading files")))
 
 async def get_files_in_blob(media_storage: AsyncAzureBlobStorage):
     files = await media_storage.aget_all_files_properties()
     print(files[:5])
     
 async def upload_folder():
-    folder_path = "/home/rash598/rash598_byoeb/byoeb/byoeb-v1/byoeb/byoeb/update_documents"
+    folder_path = UPDATE_DOCUMENTS_DIR
     account_url = "https://khushibabyashastorage.blob.core.windows.net"
     container_name = "ashacontainer"
 
@@ -35,10 +39,9 @@ async def upload_file():
     account_url = "https://khushibabyashastorage.blob.core.windows.net"
     container_name = "ashacontainer"
 
-    file_path = "/home/rash598/Khushi/byoeb/byoeb-v1/byoeb/byoeb/scripts/knowledge_base/laado_scheme.txt"
+    file_path = DEFAULT_UPLOAD_FILE
     await upload_file_to_blob(amedia_storage, file_path)
     await amedia_storage._close()
 
 if __name__ == "__main__":
     asyncio.run(upload_file())
-

--- a/byoeb-v1/byoeb/byoeb/services/knowledge_base/azure_vector_search.py
+++ b/byoeb-v1/byoeb/byoeb/services/knowledge_base/azure_vector_search.py
@@ -72,9 +72,6 @@ async def abulk_download_files(
                 files_data.append(response)
     return files_data
 
-def delete_kb():
-    vector_store.delete_store()
-
 async def main():
     await create_kb_from_blob_store()
     await amedia_storage._close()

--- a/byoeb-v1/byoeb/byoeb/services/knowledge_base/local_chromadb.py
+++ b/byoeb-v1/byoeb/byoeb/services/knowledge_base/local_chromadb.py
@@ -19,10 +19,10 @@ text_parser = LLamaIndexTextParser(
     )
 
 async def create_kb_from_blob_store():
-    logger.info("📦 Step 1: Deleting existing vector store")
+    logger.info("📦 Step 1: Format existing vector store")
     try:
-        vector_store.delete_store()
-        logger.info("✅ Successfully deleted existing store")
+        vector_store.rebuild_store()
+        logger.info("✅ Successfully formatted existing store")
     except Exception as e:
         logger.warning(f"⚠️  Error deleting store (may not exist): {str(e)}")
     
@@ -123,6 +123,3 @@ async def abulk_download_files(
     
     logger.info(f"✅ Successfully downloaded {len(files_data)}/{len(all_files)} files")
     return files_data
-
-def delete_kb():
-    vector_store.delete_store()


### PR DESCRIPTION
## Introduction
At the moment, Azure index setup has to be done manually through the UI. This change adds a unified rebuild_store() flow so kb_app can automatically recreate vector stores (Azure/Chroma/LlamaIndex) with the correct schema. This removes the need for manual Azure index setup and prevents missing-index/403 errors when uploading chunks.

## Changes
* Replace `delete_store()` with `rebuild_store()` in vector store implementations
* Azure: delete + recreate the full index schema programmatically
* Clean up KB scripts and paths, remove hard-coded file locations, and simplify upload logic