### PR TITLE
test-async-whatsapp: fix 500 on errored interactions

### DIFF
--- a/byoeb-v1/byoeb-integrations/byoeb_integrations/channel/tests/test_async_whatsapp.py
+++ b/byoeb-v1/byoeb-integrations/byoeb_integrations/channel/tests/test_async_whatsapp.py
@@ -426,12 +426,17 @@ def test_interactive_message():
     wa_convert.convert_interactive_message(message_1)
     assert is_wa is True
     assert message_type == "interactive"
+
     message_2 = '{"object": "whatsapp_business_account", "entry": [{"id": "423299570870294", "changes": [{"value": {"messaging_product": "whatsapp", "metadata": {"display_phone_number": "15551355272", "phone_number_id": "421395191063010"}, "contacts": [{"profile": {"name": "rahul5982439"}, "wa_id": "918837701828"}], "messages": [{"context": {"from": "15551355272", "id": "wamid.HBgMOTE4ODM3NzAxODI4FQIAERgSMzU5QTYwNzNBQUUzNjdDNjAwAA=="}, "from": "918837701828", "id": "wamid.HBgMOTE4ODM3NzAxODI4FQIAEhggNURBMjI2MUI1REREOUU1RTk0OTRDNzY4NkJEMjQxM0UA", "timestamp": "1732167786", "type": "interactive", "interactive": {"type": "list_reply", "list_reply": {"id": "f79a74e4-3d50-4cc3-ae50-86efff88f3f3", "title": " ", "description": "O1"}}}]}, "field": "messages"}]}]}'
     is_wa, message_type = wa_validate.validate_whatsapp_message(message_2)
     byoeb_message = wa_convert.convert_interactive_message(message_2)
     assert byoeb_message.reply_context.reply_id == "wamid.HBgMOTE4ODM3NzAxODI4FQIAERgSMzU5QTYwNzNBQUUzNjdDNjAwAA=="
     assert is_wa is True
     assert message_type == "interactive"
+
+    message_3 = '{"object": "whatsapp_business_account", "entry": [{"id": "200000000000001", "changes": [{"value": {"messaging_product": "whatsapp", "metadata": {"display_phone_number": "910000123456", "phone_number_id": "180000000000001"}, "contacts": [{"profile": {"name": "John Doe"}, "wa_id": "910000987654"}], "messages": [{"context": {"from": "910000123456", "id": "wamid.HBgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"}, "from": "910000987654", "id": "wamid.HBgBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB", "timestamp": "1763169977", "errors": [{"code": 131000, "title": "Something went wrong", "message": "Something went wrong", "error_data": {"details": "Unsupported webhook payload"}}], "type": "interactive"}]}, "field": "messages"}]}]}'
+    is_wa, message_type = wa_validate.validate_whatsapp_message(message_3)
+    assert is_wa is False
 
 def test_status_message():
     message = '{"object": "whatsapp_business_account", "entry": [{"id": "423299570870294", "changes": [{"value": {"messaging_product": "whatsapp", "metadata": {"display_phone_number": "15551355272", "phone_number_id": "421395191063010"}, "statuses": [{"id": "wamid.HBgMOTE4ODM3NzAxODI4FQIAERgSQjM1RjY0M0QyMkU4OUU3OTc3AA==", "status": "delivered", "timestamp": "1733170072", "recipient_id": "918837701828", "conversation": {"id": "bbc3027b762dec0714d75f270a6e9e9e", "origin": {"type": "service"}}, "pricing": {"billable": true, "pricing_model": "CBP", "category": "service"}}]}, "field": "messages"}]}]}'

--- a/byoeb-v1/byoeb-integrations/byoeb_integrations/channel/whatsapp/validate_message.py
+++ b/byoeb-v1/byoeb-integrations/byoeb_integrations/channel/whatsapp/validate_message.py
@@ -30,7 +30,8 @@ def validate_interactive_message(original_message):
         original_message = json.loads(original_message)
     try:
         interactive_message = incoming_message.WhatsAppInteractiveMessageBody.model_validate(original_message)
-        if interactive_message.entry[0].changes[0].value.messages[0].type == "interactive":
+        message_field = interactive_message.entry[0].changes[0].value.messages[0]
+        if message_field.type == "interactive" and message_field.interactive is not None:
             return True
     except Exception:
         return False


### PR DESCRIPTION
## Introduction
WhatsApp "interactive" messages can arrive with an `errors` field and therefore no interactive payload. These were still passing validation and later caused a 500 when converter tried to process missing fields. This PR updates validation so that errored interactive messages are recognized as invalid before conversion.

<details>
<summary>The payload used for testing was collected in the wild (with all PI stripped):</summary>

```json
{
    "object": "whatsapp_business_account",
    "entry": [
        {
            "id": "200000000000001",
            "changes": [
                {
                    "value": {
                        "messaging_product": "whatsapp",
                        "metadata": {
                            "display_phone_number": "910000123456",
                            "phone_number_id": "180000000000001"
                        },
                        "contacts": [
                            {
                                "profile": {
                                    "name": "John Doe"
                                },
                                "wa_id": "910000987654"
                            }
                        ],
                        "messages": [
                            {
                                "context": {
                                    "from": "910000123456",
                                    "id": "wamid.HBgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
                                },
                                "from": "910000987654",
                                "id": "wamid.HBgBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
                                "timestamp": "1763169977",
                                "errors": [
                                    {
                                        "code": 131000,
                                        "title": "Something went wrong",
                                        "message": "Something went wrong",
                                        "error_data": {
                                            "details": "Unsupported webhook payload"
                                        }
                                    }
                                ],
                                "type": "interactive"
                            }
                        ]
                    },
                    "field": "messages"
                }
            ]
        }
    ]
}
```
</details>

## Changes
* Add failing unit test reproducing the malformed interactive message seen in production
* Update validator to require both `type == "interactive"` and a non-null `interactive` payload
* <details>
   <summary>Fix the following 500 error when consuming interactive messages:</summary>
   
   ```
   2025-11-18T09:38:00.4524773Z INFO:     169.254.129.1:11315 - "POST /receive HTTP/1.1" 500 Internal Server Error
   2025-11-18T09:38:00.4534317Z ERROR:    Exception in ASGI application
   2025-11-18T09:38:00.4534585Z Traceback (most recent call last):
   2025-11-18T09:38:00.4534658Z   File "/tmp/8de18590cbf1cba/antenv/lib/python3.10/site-packages/uvicorn/protocols/http/httptools_impl.py", line 409, in run_asgi
   2025-11-18T09:38:00.4534691Z     result = await app(  # type: ignore[func-returns-value]
   2025-11-18T09:38:00.4534724Z   File "/tmp/8de18590cbf1cba/antenv/lib/python3.10/site-packages/uvicorn/middleware/proxy_headers.py", line 60, in __call__
   2025-11-18T09:38:00.4534749Z     return await self.app(scope, receive, send)
   2025-11-18T09:38:00.4534775Z   File "/tmp/8de18590cbf1cba/antenv/lib/python3.10/site-packages/fastapi/applications.py", line 1054, in __call__
   2025-11-18T09:38:00.453483Z     await super().__call__(scope, receive, send)
   2025-11-18T09:38:00.4534858Z   File "/tmp/8de18590cbf1cba/antenv/lib/python3.10/site-packages/starlette/applications.py", line 112, in __call__
   2025-11-18T09:38:00.4534881Z     await self.middleware_stack(scope, receive, send)
   2025-11-18T09:38:00.4534908Z   File "/tmp/8de18590cbf1cba/antenv/lib/python3.10/site-packages/starlette/middleware/errors.py", line 187, in __call__
   2025-11-18T09:38:00.4534928Z     raise exc
   2025-11-18T09:38:00.4534957Z   File "/tmp/8de18590cbf1cba/antenv/lib/python3.10/site-packages/starlette/middleware/errors.py", line 165, in __call__
   2025-11-18T09:38:00.4534982Z     await self.app(scope, receive, _send)
   2025-11-18T09:38:00.4535009Z   File "/tmp/8de18590cbf1cba/antenv/lib/python3.10/site-packages/opentelemetry/instrumentation/asgi/__init__.py", line 795, in __call__
   2025-11-18T09:38:00.453504Z     await self.app(scope, otel_receive, otel_send)
   2025-11-18T09:38:00.4535069Z   File "/tmp/8de18590cbf1cba/antenv/lib/python3.10/site-packages/starlette/middleware/errors.py", line 187, in __call__
   2025-11-18T09:38:00.4535108Z     raise exc
   2025-11-18T09:38:00.4535136Z   File "/tmp/8de18590cbf1cba/antenv/lib/python3.10/site-packages/starlette/middleware/errors.py", line 165, in __call__
   2025-11-18T09:38:00.4535158Z     await self.app(scope, receive, _send)
   2025-11-18T09:38:00.4535187Z   File "/tmp/8de18590cbf1cba/antenv/lib/python3.10/site-packages/opentelemetry/instrumentation/fastapi/__init__.py", line 307, in __call__
   2025-11-18T09:38:00.4535212Z     await self.app(scope, receive, send)
   2025-11-18T09:38:00.453524Z   File "/tmp/8de18590cbf1cba/antenv/lib/python3.10/site-packages/starlette/middleware/exceptions.py", line 62, in __call__
   2025-11-18T09:38:00.4535286Z     await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
   2025-11-18T09:38:00.453532Z   File "/tmp/8de18590cbf1cba/antenv/lib/python3.10/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
   2025-11-18T09:38:00.4535344Z     raise exc
   2025-11-18T09:38:00.4535386Z   File "/tmp/8de18590cbf1cba/antenv/lib/python3.10/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
   2025-11-18T09:38:00.4535428Z     await app(scope, receive, sender)
   2025-11-18T09:38:00.4535467Z   File "/tmp/8de18590cbf1cba/antenv/lib/python3.10/site-packages/starlette/routing.py", line 714, in __call__
   2025-11-18T09:38:00.4535498Z     await self.middleware_stack(scope, receive, send)
   2025-11-18T09:38:00.4535532Z   File "/tmp/8de18590cbf1cba/antenv/lib/python3.10/site-packages/starlette/routing.py", line 734, in app
   2025-11-18T09:38:00.4535565Z     await route.handle(scope, receive, send)
   2025-11-18T09:38:00.45356Z   File "/tmp/8de18590cbf1cba/antenv/lib/python3.10/site-packages/starlette/routing.py", line 288, in handle
   2025-11-18T09:38:00.4535638Z     await self.app(scope, receive, send)
   2025-11-18T09:38:00.4535674Z   File "/tmp/8de18590cbf1cba/antenv/lib/python3.10/site-packages/starlette/routing.py", line 76, in app
   2025-11-18T09:38:00.4535704Z     await wrap_app_handling_exceptions(app, request)(scope, receive, send)
   2025-11-18T09:38:00.4535742Z   File "/tmp/8de18590cbf1cba/antenv/lib/python3.10/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
   2025-11-18T09:38:00.4535769Z     raise exc
   2025-11-18T09:38:00.4535819Z   File "/tmp/8de18590cbf1cba/antenv/lib/python3.10/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
   2025-11-18T09:38:00.4535849Z     await app(scope, receive, sender)
   2025-11-18T09:38:00.4535885Z   File "/tmp/8de18590cbf1cba/antenv/lib/python3.10/site-packages/starlette/routing.py", line 73, in app
   2025-11-18T09:38:00.4535917Z     response = await f(request)
   2025-11-18T09:38:00.453595Z   File "/tmp/8de18590cbf1cba/antenv/lib/python3.10/site-packages/fastapi/routing.py", line 301, in app
   2025-11-18T09:38:00.4535975Z     raw_response = await run_endpoint_function(
   2025-11-18T09:38:00.4536008Z   File "/tmp/8de18590cbf1cba/antenv/lib/python3.10/site-packages/fastapi/routing.py", line 212, in run_endpoint_function
   2025-11-18T09:38:00.453604Z     return await dependant.call(**values)
   2025-11-18T09:38:00.4536072Z   File "/tmp/8de18590cbf1cba/antenv/lib/python3.10/site-packages/byoeb/apis/chat.py", line 23, in receive
   2025-11-18T09:38:00.4536112Z     response = await dependency_setup.message_producer_handler.handle(body)
   2025-11-18T09:38:00.4536157Z   File "/tmp/8de18590cbf1cba/antenv/lib/python3.10/site-packages/byoeb/handler/message_producer.py", line 79, in handle
   2025-11-18T09:38:00.4536196Z     response, err = await message_producer_service.apublish_message(message, channel)
   2025-11-18T09:38:00.4536364Z   File "/tmp/8de18590cbf1cba/antenv/lib/python3.10/site-packages/byoeb/services/chat/message_producer.py", line 84, in apublish_message
   2025-11-18T09:38:00.4536405Z     byoeb_message = self.__convert_whatsapp_to_byoeb_message(message)
   2025-11-18T09:38:00.453645Z   File "/tmp/8de18590cbf1cba/antenv/lib/python3.10/site-packages/byoeb/services/chat/message_producer.py", line 34, in __convert_whatsapp_to_byoeb_message
   2025-11-18T09:38:00.4536484Z     byoeb_message = wa_converter.convert_whatsapp_to_byoeb_message(message, message_type)
   2025-11-18T09:38:00.4536525Z   File "/tmp/8de18590cbf1cba/antenv/lib/python3.10/site-packages/byoeb_integrations/channel/whatsapp/convert_message.py", line 146, in convert_whatsapp_to_byoeb_message
   2025-11-18T09:38:00.4536558Z     return convert_interactive_message(original_message)
   2025-11-18T09:38:00.4536599Z   File "/tmp/8de18590cbf1cba/antenv/lib/python3.10/site-packages/byoeb_integrations/channel/whatsapp/convert_message.py", line 100, in convert_interactive_message
   2025-11-18T09:38:00.4536655Z     message_type = interactive_message.entry[0].changes[0].value.messages[0].interactive.type
   2025-11-18T09:38:00.4536685Z AttributeError: 'NoneType' object has no attribute 'type'
   ```
   </details>