### PR TITLE
pyproject: use relative paths for internal libraries

### DIFF
--- a/byoeb-v1/Dockerfile
+++ b/byoeb-v1/Dockerfile
@@ -20,6 +20,9 @@ WORKDIR /app
 # Copy project files
 COPY . .
 
+# Change directory to service's root
+WORKDIR /app/byoeb
+
 # Install dependencies via Poetry
 RUN poetry install --no-root --no-interaction --no-ansi
 

--- a/byoeb-v1/byoeb-integrations/pyproject.toml
+++ b/byoeb-v1/byoeb-integrations/pyproject.toml
@@ -18,7 +18,7 @@ azure-ai-translation-text = "1.0.1"
 motor = "3.6.0"
 llama-index-vector-stores-chroma = "0.3.0"
 azure-search-documents = "11.5.2"
-byoeb-core = { git = "https://github.com/A4i-tech/byoeb.git", rev = "a4i/main", subdirectory = "byoeb-v1/byoeb-core" }
+byoeb-core = {path = "../byoeb-core", develop = true}
 pytest-mock = "^3.14.1"
 
 

--- a/byoeb-v1/byoeb/pyproject.toml
+++ b/byoeb-v1/byoeb/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 python = "^3.10"
 fastapi = "^0.115.5"
 aiocache = "0.12.3"
-byoeb-integrations = {git = "https://github.com/A4i-tech/byoeb.git", branch = "a4i/main", subdirectory = "byoeb-v1/byoeb-integrations"}
+byoeb-integrations = {path = "../byoeb-integrations", develop = true}
 azure-monitor-opentelemetry = "1.6.7"
 azure-monitor-events-extension = "0.1.0"
 croniter = "6.0.0"


### PR DESCRIPTION
## Introduction
Staging builds were still pulling internal libraries from `a4i/main` because Render couldn't resolve relative paths. This was caused by the Dockerfile being nested under `byoeb-v1/byoeb` - Dockerfiles cannot access parent directory (i.e., `cd ..`) which prevented correct path resolution for `byoeb`, `byoeb-core`, and `byoeb-integrations`.

This PR fixes that by restructuring the Dockerfile location and switching all internal dependencies to relative paths.

## Changes
* Move Dockerfile to the project root so local library paths are correctly resolved in Docker environments
* Replace git-based `byoeb-core` and `byoeb-integrations` references with relative `path = "../..."` entries

## Tests
A pre-staging service using this branch (muqsit/relative-paths-internal-libs) has bene deployed to https://byoeb-muqsit-relative-paths-internal-libs.onrender.com. It resolves paths to relative directories without any issue.

<details>
<summary><code>[7/7] RUN poetry install --no-root --no-interaction --no-ansi</code></summary>

```
#12 [7/7] RUN poetry install --no-root --no-interaction --no-ansi
#12 0.470 Skipping virtualenv creation, as specified in config file.
#12 0.655 Updating dependencies
#12 0.655 Resolving dependencies...
#12 135.9 
#12 135.9 Package operations: 208 installs, 3 updates, 0 removals
#12 135.9 
#12 135.9   - Installing frozenlist (1.8.0)
#12 135.9   - Installing h11 (0.16.0)
#12 135.9   - Installing multidict (6.7.0)
#12 135.9   - Installing mypy-extensions (1.1.0)
#12 135.9   - Installing propcache (0.4.1)
#12 135.9   - Installing sniffio (1.3.1)
#12 135.9   - Installing typing-extensions (4.15.0)
#12 135.9   - Downgrading urllib3 (2.5.0 -> 2.3.0)
#12 159.6   - Installing aiohappyeyeballs (2.6.1)
#12 159.6   - Installing aiosignal (1.4.0)
#12 159.6   - Installing annotated-types (0.7.0)
#12 159.6   - Installing anyio (4.11.0)
#12 159.6   - Installing attrs (25.4.0)
#12 159.6   - Installing click (8.1.8)
#12 159.6   - Installing greenlet (3.2.4)
#12 159.6   - Installing httpcore (1.0.9)
#12 159.6   - Installing joblib (1.5.2)
#12 159.6   - Installing marshmallow (3.26.1)
#12 159.6   - Installing pydantic-core (2.41.5)
#12 159.6   - Installing regex (2025.11.3)
#12 159.6   - Installing tqdm (4.67.1)
#12 159.6   - Installing typing-inspect (0.9.0)
#12 159.6   - Installing typing-inspection (0.4.2)
#12 159.7   - Installing wrapt (1.17.3)
#12 159.7   - Installing yarl (1.22.0)
#12 160.5   - Installing aiohttp (3.13.2)
#12 160.5   - Installing dataclasses-json (0.6.7)
#12 160.5   - Installing deprecated (1.3.1)
#12 160.5   - Installing dirtyjson (1.0.8)
#12 160.5   - Installing distro (1.9.0)
#12 160.5   - Installing filetype (1.2.0)
#12 160.5   - Installing fsspec (2025.10.0)
#12 160.5   - Installing httpx (0.28.1)
#12 160.5   - Installing jiter (0.12.0)
#12 160.5   - Installing nest-asyncio (1.6.0)
#12 160.5   - Installing networkx (3.4.2)
#12 160.5   - Installing nltk (3.9.2)
#12 160.5   - Installing numpy (1.26.4)
#12 160.5   - Installing pillow (12.0.0)
#12 160.5   - Installing pydantic (2.12.4)
#12 160.5   - Installing pyyaml (6.0.3)
#12 160.5   - Installing sqlalchemy (2.0.44)
#12 160.6   - Installing tenacity (8.5.0)
#12 160.6   - Installing tiktoken (0.12.0)
#12 162.4   - Installing llama-index-core (0.11.23)
#12 162.4   - Installing openai (1.58.1)
#12 162.4   - Installing opentelemetry-api (1.38.0)
#12 162.7   - Installing llama-cloud (0.1.19)
#12 162.7   - Installing llama-index-llms-openai (0.2.16)
#12 162.7   - Installing mdurl (0.1.2)
#12 162.7   - Installing opentelemetry-semantic-conventions (0.59b0)
#12 162.7   - Installing protobuf (6.33.1)
#12 162.7   - Installing pyasn1 (0.6.1)
#12 162.7   - Installing pyjwt (2.10.1)
#12 162.7   - Installing python-dotenv (1.2.1)
#12 162.7   - Installing six (1.17.0)
#12 162.9   - Installing asgiref (3.10.0)
#12 162.9   - Installing cachetools (6.2.2)
#12 162.9   - Installing hf-xet (1.2.0)
#12 162.9   - Installing humanfriendly (10.0)
#12 162.9   - Installing llama-cloud-services (0.6.21)
#12 162.9   - Installing llama-index-agent-openai (0.3.4)
#12 162.9   - Installing markdown-it-py (4.0.0)
#12 162.9   - Installing mpmath (1.3.0)
#12 162.9   - Installing msal (1.34.0)
#12 162.9   - Installing oauthlib (3.3.1)
#12 162.9   - Installing opentelemetry-instrumentation (0.59b0)
#12 162.9   - Installing opentelemetry-proto (1.38.0)
#12 162.9   - Installing opentelemetry-util-http (0.59b0)
#12 162.9   - Installing pyasn1-modules (0.4.2)
#12 162.9   - Installing pygments (2.19.2)
#12 162.9   - Installing python-dateutil (2.9.0.post0)
#12 162.9   - Installing pytz (2025.2)
#12 162.9   - Installing rpds-py (0.29.0)
#12 162.9   - Installing rsa (4.9.1)
#12 162.9   - Installing soupsieve (2.8)
#12 163.0   - Installing tzdata (2025.2)
#12 163.7   - Installing azure-core (1.36.0)
#12 163.7   - Installing backoff (2.2.1)
#12 163.7   - Installing backports-tarfile (1.2.0)
#12 163.7   - Installing beautifulsoup4 (4.14.2)
#12 163.7   - Installing coloredlogs (15.0.1)
#12 163.7   - Installing durationpy (0.10)
#12 163.7   - Installing flatbuffers (25.9.23)
#12 163.7   - Installing google-auth (2.43.0)
#12 163.7   - Installing googleapis-common-protos (1.72.0)
#12 163.7   - Installing grpcio (1.76.0)
#12 163.7   - Installing httptools (0.7.1)
#12 163.7   - Installing huggingface-hub (0.36.0)
#12 163.7   - Installing llama-index-embeddings-openai (0.2.5)
#12 163.7   - Installing llama-index-program-openai (0.2.0)
#12 163.7   - Installing llama-parse (0.6.21)
#12 163.7   - Installing msal-extensions (1.3.1)
#12 163.7   - Installing opentelemetry-exporter-otlp-proto-common (1.38.0)
#12 163.7   - Installing opentelemetry-instrumentation-asgi (0.59b0)
#12 163.7   - Installing opentelemetry-sdk (1.38.0)
#12 163.7   - Installing pandas (2.3.3)
#12 163.9 Installing /usr/local/bin/llama-parse over existing file
#12 163.9   - Installing pypdf (5.9.0)
#12 163.9   - Installing referencing (0.36.2)
#12 164.0   - Installing requests-oauthlib (2.0.0)
#12 164.0   - Installing rich (14.2.0)
#12 164.0   - Installing starlette (0.46.2)
#12 164.0   - Installing striprtf (0.0.26)
#12 164.0   - Installing sympy (1.14.0)
#12 164.0   - Installing uvloop (0.22.1)
#12 164.0   - Installing watchfiles (1.1.1)
#12 164.0   - Installing websocket-client (1.9.0)
#12 164.0   - Installing websockets (15.0.1)
#12 165.7   - Installing azure-identity (1.25.1)
#12 165.7   - Installing bcrypt (5.0.0)
#12 165.7   - Installing beartype (0.22.5)
#12 165.7   - Installing chroma-hnswlib (0.7.6)
#12 165.7   - Installing dnspython (2.8.0)
#12 165.7   - Installing docutils (0.22.3)
#12 165.7   - Installing fastapi (0.115.14)
#12 165.7   - Installing future (1.0.0)
#12 165.7   - Installing importlib-resources (6.5.2)
#12 165.7   - Installing iniconfig (2.3.0)
#12 165.7   - Installing isodate (0.7.2)
#12 165.7   - Installing jaraco-context (6.0.1)
#12 165.7   - Installing jaraco-functools (4.3.0)
#12 165.8   - Installing jsonschema-specifications (2025.9.1)
#12 165.8   - Installing kubernetes (34.1.0)
#12 165.8   - Installing llama-index-cli (0.3.1)
#12 165.8   - Installing llama-index-indices-managed-llama-cloud (0.6.0)
#12 165.8   - Installing llama-index-legacy (0.9.48.post4)
#12 165.8   - Installing llama-index-multi-modal-llms-openai (0.2.3)
#12 165.8   - Installing llama-index-question-gen-openai (0.2.0)
#12 166.0   - Installing llama-index-readers-file (0.3.0)
#12 166.0   - Installing llama-index-readers-llama-parse (0.3.0)
#12 166.0   - Installing mmh3 (5.2.0)
#12 166.0   - Installing onnxruntime (1.23.2)
#12 166.1   - Installing opentelemetry-exporter-otlp-proto-grpc (1.38.0)
#12 166.2   - Installing opentelemetry-instrumentation-fastapi (0.59b0)
#12 166.2   - Installing orjson (3.11.4)
#12 166.2   - Installing overrides (7.7.0)
#12 166.2   - Installing pluggy (1.6.0)
#12 166.2   - Installing posthog (7.0.1)
#12 166.3   - Installing pypika (0.48.9)
#12 166.3   - Installing tokenizers (0.20.3)
#12 166.3   - Installing typer (0.20.0)
#12 166.3   - Installing uvicorn (0.35.0)
#12 168.5   - Installing azure-common (1.1.28)
#12 168.5   - Installing chromadb (0.5.23)
#12 168.5   - Installing diskcache (5.6.3)
#12 168.5   - Installing docstring-parser (0.17.0)
#12 168.5   - Installing email-validator (2.3.0)
#12 168.5   - Installing ffmpeg-python (0.2.0)
#12 168.5   - Installing gtts (2.5.4)
#12 168.5   - Installing httpx-sse (0.4.3)
#12 168.5   - Installing jsonschema (4.25.1)
#12 168.5   - Updating keyring (24.3.1 -> 25.7.0)
#12 168.5   - Installing llama-index (0.11.23)
#12 168.5   - Installing llama-index-llms-azure-openai (0.2.2)
#12 168.5   - Installing msrest (0.7.1)
#12 168.5   - Installing opentelemetry-instrumentation-dbapi (0.59b0)
#12 168.5   - Installing opentelemetry-instrumentation-wsgi (0.59b0)
#12 168.5   - Installing pathable (0.4.4)
#12 168.5   - Installing pathvalidate (3.3.1)
#12 168.5   - Installing psutil (7.1.3)
#12 168.5   - Installing py-key-value-shared (0.2.8)
#12 168.5   - Installing pydantic-settings (2.12.0)
#12 168.7 Installing /usr/local/bin/llamaindex-cli over existing file
#12 168.7   - Installing pydub (0.25.1)
#12 168.7   - Installing pymongo (4.9.2)
#12 168.7   - Installing pytest (8.4.2)
#12 168.7   - Installing python-multipart (0.0.20)
#12 168.7   - Installing rich-rst (1.3.2)
#12 168.7   - Installing sse-starlette (3.0.3)
#12 171.0   - Installing authlib (1.6.5)
#12 171.0   - Installing azure-ai-translation-text (1.0.1)
#12 171.0   - Installing azure-cognitiveservices-speech (1.41.1)
#12 171.0   - Installing azure-core-tracing-opentelemetry (1.0.0b12)
#12 171.0   - Installing azure-monitor-opentelemetry-exporter (1.0.0b45)
#12 171.0   - Installing azure-search-documents (11.5.2)
#12 171.0   - Installing azure-storage-blob (12.24.0)
#12 171.0   - Installing azure-storage-queue (12.12.0)
#12 171.0   - Installing coverage (7.11.3)
#12 171.0   - Installing cyclopts (4.2.4)
#12 171.0   - Installing et-xmlfile (2.0.0)
#12 171.0   - Installing exceptiongroup (1.3.0)
#12 171.0   - Installing jsonschema-path (0.3.4)
#12 171.0   - Installing llama-index-embeddings-azure-openai (0.2.5)
#12 171.0   - Installing llama-index-vector-stores-chroma (0.3.0)
#12 171.0   - Installing markupsafe (3.0.3)
#12 171.0   - Installing mcp (1.21.2)
#12 171.0   - Installing motor (3.6.0)
#12 171.0   - Installing openapi-pydantic (0.5.1)
#12 171.0   - Installing opentelemetry-instrumentation-django (0.59b0)
#12 171.1   - Installing opentelemetry-instrumentation-flask (0.59b0)
#12 171.1   - Installing opentelemetry-instrumentation-psycopg2 (0.59b0)
#12 171.1   - Installing opentelemetry-instrumentation-requests (0.59b0)
#12 171.1   - Installing opentelemetry-instrumentation-urllib (0.59b0)
#12 171.2   - Installing opentelemetry-instrumentation-urllib3 (0.59b0)
#12 171.2   - Installing opentelemetry-resource-detector-azure (0.1.5)
#12 171.2   - Installing py-key-value-aio (0.2.8)
#12 171.3   - Installing pyperclip (1.11.0)
#12 171.3   - Installing pytest-mock (3.15.1)
#12 171.3   - Installing tzlocal (5.3.1)
#12 172.7   - Installing byoeb-core (0.1.0 /app/byoeb-core)
#12 173.3   - Installing aiocache (0.12.3)
#12 173.3   - Installing apscheduler (3.11.1)
#12 173.3   - Installing azure-monitor-events-extension (0.1.0)
#12 173.3   - Installing azure-monitor-opentelemetry (1.6.7)
#12 173.3   - Installing croniter (6.0.0)
#12 173.3   - Installing fastmcp (2.13.1)
#12 173.3   - Installing jinja2 (3.1.6)
#12 173.3   - Installing openpyxl (3.1.5)
#12 173.3   - Installing pytest-asyncio (1.3.0)
#12 173.3   - Installing pytest-cov (7.0.0)
#12 173.3   - Downgrading rapidfuzz (3.14.3 -> 3.13.0)
#12 174.8   - Installing byoeb-integrations (0.1.0 /app/byoeb-integrations)
#12 176.3 
#12 176.3 Writing lock file
#12 DONE 221.2s
```
</details>

## Follow-up steps
Update ASHABot services on Render to use `byoeb-v1` as project root instead of `byoeb-v1/byoeb`.