### PR TITLE
ci/cd: use same staging-deploy environment as azure webapp

### DIFF
--- a/.github/workflows/ci-cd-pipeline.yml
+++ b/.github/workflows/ci-cd-pipeline.yml
@@ -2,9 +2,9 @@ name: CI/CD Pipeline
 
 on:
   push:
-    branches: [ "a4i/main", "muqsit/docker-azure-env" ]
+    branches: [ "a4i/main", "staging" ]
   pull_request:
-    branches: [ "a4i/main", "muqsit/docker-azure-env" ]
+    branches: [ "a4i/main", "staging" ]
   workflow_dispatch:
 
 env:
@@ -96,7 +96,7 @@ jobs:
   publish-image:
     name: Publish image
     needs: [build, unit-test-byoeb-core, unit-test-byoeb, unit-test-byoeb-integrations]
-    if: success() && github.event_name == 'push' && (github.ref_name == 'muqsit/docker-azure-env' || github.ref_name == 'a4i/main')
+    if: success() && github.event_name == 'push' && (github.ref_name == 'staging' || github.ref_name == 'a4i/main')
     runs-on: ubuntu-latest
     outputs:
       image-tag: ${{ steps.image-info.outputs.tag }}
@@ -120,7 +120,7 @@ jobs:
         run: |
           set -euo pipefail
           case "$REF_NAME" in
-            muqsit/docker-azure-env)
+            staging)
               echo "environment=staging" >> "$GITHUB_OUTPUT"
               echo "tag_prefix=staging" >> "$GITHUB_OUTPUT"
               ;;
@@ -180,7 +180,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Notify Teams of publish failure
-        if: ${{ failure() && github.event_name != 'pull_request' && (github.ref_name == 'muqsit/docker-azure-env' || github.ref_name == 'a4i/main') }}
+        if: ${{ failure() && github.event_name != 'pull_request' && (github.ref_name == 'staging' || github.ref_name == 'a4i/main') }}
         uses: ./.github/actions/dispatch-teams-webhook
         with:
           summary: '❌ Pipeline Stage Failed'

--- a/.github/workflows/ci-cd-pipeline.yml
+++ b/.github/workflows/ci-cd-pipeline.yml
@@ -2,9 +2,9 @@ name: CI/CD Pipeline
 
 on:
   push:
-    branches: [ "a4i/main", "staging" ]
+    branches: [ "a4i/main", "muqsit/docker-azure-env" ]
   pull_request:
-    branches: [ "a4i/main", "staging" ]
+    branches: [ "a4i/main", "muqsit/docker-azure-env" ]
   workflow_dispatch:
 
 env:
@@ -96,7 +96,7 @@ jobs:
   publish-image:
     name: Publish image
     needs: [build, unit-test-byoeb-core, unit-test-byoeb, unit-test-byoeb-integrations]
-    if: success() && github.event_name == 'push' && (github.ref_name == 'staging' || github.ref_name == 'a4i/main')
+    if: success() && github.event_name == 'push' && (github.ref_name == 'muqsit/docker-azure-env' || github.ref_name == 'a4i/main')
     runs-on: ubuntu-latest
     outputs:
       image-tag: ${{ steps.image-info.outputs.tag }}
@@ -120,7 +120,7 @@ jobs:
         run: |
           set -euo pipefail
           case "$REF_NAME" in
-            staging)
+            muqsit/docker-azure-env)
               echo "environment=staging" >> "$GITHUB_OUTPUT"
               echo "tag_prefix=staging" >> "$GITHUB_OUTPUT"
               ;;
@@ -180,7 +180,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Notify Teams of publish failure
-        if: ${{ failure() && github.event_name != 'pull_request' && (github.ref_name == 'staging' || github.ref_name == 'a4i/main') }}
+        if: ${{ failure() && github.event_name != 'pull_request' && (github.ref_name == 'muqsit/docker-azure-env' || github.ref_name == 'a4i/main') }}
         uses: ./.github/actions/dispatch-teams-webhook
         with:
           summary: '❌ Pipeline Stage Failed'

--- a/byoeb-v1/Dockerfile
+++ b/byoeb-v1/Dockerfile
@@ -1,5 +1,5 @@
 # Use an official Python runtime
-FROM python:3.11-slim
+FROM python:3.11-slim-bullseye
 
 # Set environment variables
 ENV PYTHONUNBUFFERED=1 \

--- a/byoeb-v1/byoeb/byoeb/chat_app/run.py
+++ b/byoeb-v1/byoeb/byoeb/chat_app/run.py
@@ -1,3 +1,9 @@
+# fixes crash during 'import chromadb' - see: https://docs.trychroma.com/docs/overview/troubleshooting#sqlite
+import sys
+__import__("pysqlite3")
+sys.modules["sqlite3"] = sys.modules.pop("pysqlite3")
+
+
 import logging
 import logging.config
 import os

--- a/byoeb-v1/byoeb/pyproject.toml
+++ b/byoeb-v1/byoeb/pyproject.toml
@@ -21,6 +21,7 @@ python-dotenv = "^1.1.1"
 fastmcp = "^2.12.3"
 apscheduler = "^3.11.0"
 jinja2 = "^3.1.6"
+pysqlite3-binary = "^0.5.4"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.4.1"


### PR DESCRIPTION
## Introduction
Azure WebApp instances are deployed on Debian 11 "Bullseye" (August 14th, 2021) which is past its standard support and currently in its LTS phase. This means it only receives security updates and as a consequence, it is locked at `libsqlite3` v3.34. Libraries like chromadb require minimum 3.35.

While deployments work on other (later) OS releases, they crash production. Goal here is to replicate the same environment that Azure WebApps use, so such issues can be caught during staging deployment itself.

## Approach
ChromaDB lists several workarounds for this very issue - https://docs.trychroma.com/docs/overview/troubleshooting#sqlite. The approach selected here aligns with existing workarounds present in BYOEB parent repository: https://github.com/gmh5225/byoeb/blob/f50cc1f0dd9c64289029e038afc43bb275437565/src/knowledge_base.py#L4-L7

## Changes
- Switched base image in Dockerfile from `python:3.11-slim` → `python:3.11-slim-bullseye` to align with Azure WebApp's Debian 11 ("Bullseye") environment.

## Tests
Commit history confirms the changes work as expected through successful staging builds and deployments:
- Existing builds cause [deploy failure](https://github.com/A4i-tech/byoeb/actions/runs/19662395629/job/56311779983) on Debian 11
- Fix confirms [successful deploys](https://github.com/A4i-tech/byoeb/actions/runs/19662785225/job/56312942226) on Debian 11