### PR TITLE
python: upgrade to 3.11

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: ${{ inputs.directory }}
-        run: poetry sync --no-interaction --no-ansi
+        run: poetry lock --no-interaction --no-ansi && poetry install --no-interaction
 
       - name: Run tests
         if: ${{ inputs.tests-path != '' }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: ${{ inputs.directory }}
-        run: poetry lock --no-interaction --no-ansi && poetry install --no-interaction
+        run: poetry sync --no-interaction --no-ansi
 
       - name: Run tests
         if: ${{ inputs.tests-path != '' }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
           cache: "poetry"
           cache-dependency-path: |
             ${{ inputs.directory }}/pyproject.toml

--- a/byoeb-v1/Dockerfile
+++ b/byoeb-v1/Dockerfile
@@ -18,14 +18,21 @@ RUN pip install "poetry==$POETRY_VERSION"
 WORKDIR /app
 
 # Copy dependency manifests and local path packages first for better caching
+COPY byoeb ./byoeb
 COPY byoeb/pyproject.toml ./byoeb/
 COPY byoeb/poetry.lock* ./byoeb/
+
 COPY byoeb-integrations ./byoeb-integrations
+COPY byoeb-integrations/pyproject.toml ./byoeb-integrations/
+COPY byoeb-integrations/poetry.lock* ./byoeb-integrations/
+
 COPY byoeb-core ./byoeb-core
+COPY byoeb-core/pyproject.toml ./byoeb-core/
+COPY byoeb-core/poetry.lock* ./byoeb-core/
 
 # Change directory to service's root and install dependencies via Poetry
 WORKDIR /app/byoeb
-RUN poetry install --no-root --no-interaction --no-ansi
+RUN poetry lock --no-interaction --no-ansi && poetry install --no-root --no-interaction --no-ansi
 
 # Copy the full project after dependencies are cached
 WORKDIR /app

--- a/byoeb-v1/byoeb-core/pyproject.toml
+++ b/byoeb-v1/byoeb-core/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Your Name <you@example.com>"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^3.10"
+python = "^3.11"
 llama-index = "0.11.23"
 gtts = "2.5.4"
 pydub = "0.25.1"

--- a/byoeb-v1/byoeb-integrations/pyproject.toml
+++ b/byoeb-v1/byoeb-integrations/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 exclude = ["**/tests/**", "**/tests"]
 
 [tool.poetry.dependencies]
-python = "^3.10"
+python = "^3.11"
 openai = "1.58.1"
 chromadb = "0.5.23"
 llama-index-embeddings-azure-openai = "0.2.5"

--- a/byoeb-v1/byoeb/README.md
+++ b/byoeb-v1/byoeb/README.md
@@ -54,7 +54,7 @@ byoeb/
 ## Installation & Setup
 
 ### Prerequisites
-- Python 3.10+
+- Python 3.11+
 - Poetry (dependency management)
 - Azure account with required services
 - WhatsApp Business API access

--- a/byoeb-v1/byoeb/pyproject.toml
+++ b/byoeb-v1/byoeb/pyproject.toml
@@ -10,6 +10,8 @@ python = "^3.11"
 fastapi = "^0.115.5"
 aiocache = "0.12.3"
 byoeb-integrations = {path = "../byoeb-integrations", develop = true}
+opentelemetry-api = "1.38.0"
+opentelemetry-sdk = "1.38.0"
 azure-monitor-opentelemetry = "1.6.7"
 azure-monitor-events-extension = "0.1.0"
 croniter = "6.0.0"

--- a/byoeb-v1/byoeb/pyproject.toml
+++ b/byoeb-v1/byoeb/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Rahul Sharma <rahul5982439@gmail.com>"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^3.10"
+python = "^3.11"
 fastapi = "^0.115.5"
 aiocache = "0.12.3"
 byoeb-integrations = {path = "../byoeb-integrations", develop = true}


### PR DESCRIPTION
## Introduction
Python 3.10 is being phased out on Azure, blocking future deployments. This update moves the project to Python 3.11 to ensure compatibility and continued support.

## Changes
- Update Python version across all modules (byoeb, core, integrations)
- Update GitHub Actions to run on 3.11
- Widen Dockerfile cache mechanism to cover core, integrations (reduces "Build Docker image" time from [3.5m](https://github.com/A4i-tech/byoeb/actions/runs/19914983496/attempts/1) to [20s](https://github.com/A4i-tech/byoeb/actions/runs/19914983496/attempts/2))