### PR TITLE
POST /asha_logs: tweak setup, add integration tests

### DIFF
--- a/.github/workflows/ci-cd-pipeline.yml
+++ b/.github/workflows/ci-cd-pipeline.yml
@@ -2,9 +2,9 @@ name: CI/CD Pipeline
 
 on:
   push:
-    branches: [ "a4i/main", "muqsit/asha-logs-api-tweaks" ]
+    branches: [ "a4i/main", "staging" ]
   pull_request:
-    branches: [ "a4i/main", "muqsit/asha-logs-api-tweaks" ]
+    branches: [ "a4i/main", "staging" ]
   workflow_dispatch:
 
 env:
@@ -97,7 +97,7 @@ jobs:
   publish-image:
     name: Publish image
     needs: [build, unit-test-byoeb-core, unit-test-byoeb, unit-test-byoeb-integrations]
-    if: success() && github.event_name == 'push' && (github.ref_name == 'muqsit/asha-logs-api-tweaks' || github.ref_name == 'a4i/main')
+    if: success() && github.event_name == 'push' && (github.ref_name == 'staging' || github.ref_name == 'a4i/main')
     runs-on: ubuntu-latest
     outputs:
       image-tag: ${{ steps.image-info.outputs.tag }}
@@ -121,7 +121,7 @@ jobs:
         run: |
           set -euo pipefail
           case "$REF_NAME" in
-            muqsit/asha-logs-api-tweaks)
+            staging)
               echo "environment=staging" >> "$GITHUB_OUTPUT"
               echo "tag_prefix=staging" >> "$GITHUB_OUTPUT"
               ;;
@@ -181,7 +181,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Notify Teams of publish failure
-        if: ${{ failure() && github.event_name != 'pull_request' && (github.ref_name == 'muqsit/asha-logs-api-tweaks' || github.ref_name == 'a4i/main') }}
+        if: ${{ failure() && github.event_name != 'pull_request' && (github.ref_name == 'staging' || github.ref_name == 'a4i/main') }}
         uses: ./.github/actions/dispatch-teams-webhook
         with:
           summary: '❌ Pipeline Stage Failed'

--- a/.github/workflows/ci-cd-pipeline.yml
+++ b/.github/workflows/ci-cd-pipeline.yml
@@ -2,9 +2,9 @@ name: CI/CD Pipeline
 
 on:
   push:
-    branches: [ "a4i/main", "staging" ]
+    branches: [ "a4i/main", "muqsit/asha-logs-api-tweaks" ]
   pull_request:
-    branches: [ "a4i/main", "staging" ]
+    branches: [ "a4i/main", "muqsit/asha-logs-api-tweaks" ]
   workflow_dispatch:
 
 env:
@@ -97,7 +97,7 @@ jobs:
   publish-image:
     name: Publish image
     needs: [build, unit-test-byoeb-core, unit-test-byoeb, unit-test-byoeb-integrations]
-    if: success() && github.event_name == 'push' && (github.ref_name == 'staging' || github.ref_name == 'a4i/main')
+    if: success() && github.event_name == 'push' && (github.ref_name == 'muqsit/asha-logs-api-tweaks' || github.ref_name == 'a4i/main')
     runs-on: ubuntu-latest
     outputs:
       image-tag: ${{ steps.image-info.outputs.tag }}
@@ -121,7 +121,7 @@ jobs:
         run: |
           set -euo pipefail
           case "$REF_NAME" in
-            staging)
+            muqsit/asha-logs-api-tweaks)
               echo "environment=staging" >> "$GITHUB_OUTPUT"
               echo "tag_prefix=staging" >> "$GITHUB_OUTPUT"
               ;;
@@ -181,7 +181,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Notify Teams of publish failure
-        if: ${{ failure() && github.event_name != 'pull_request' && (github.ref_name == 'staging' || github.ref_name == 'a4i/main') }}
+        if: ${{ failure() && github.event_name != 'pull_request' && (github.ref_name == 'muqsit/asha-logs-api-tweaks' || github.ref_name == 'a4i/main') }}
         uses: ./.github/actions/dispatch-teams-webhook
         with:
           summary: '❌ Pipeline Stage Failed'

--- a/byoeb-v1/byoeb-core/byoeb_core/media_storage/base.py
+++ b/byoeb-v1/byoeb-core/byoeb_core/media_storage/base.py
@@ -36,6 +36,6 @@ class BaseMediaStorage(ABC):
     @abstractmethod
     async def adelete_file(
         self,
-        blob_name: str,
+        file_name: str,
     ) -> Any:
         pass

--- a/byoeb-v1/byoeb/byoeb/apis/admin.py
+++ b/byoeb-v1/byoeb/byoeb/apis/admin.py
@@ -2,12 +2,9 @@ import os
 from byoeb.models.experiment import QueryInput
 from io import BytesIO
 from datetime import datetime
-from fastapi import APIRouter, Request
-from fastapi.responses import JSONResponse
-from fastapi import Form, Request
-from fastapi.responses import HTMLResponse, StreamingResponse
+from fastapi import APIRouter, Form, HTTPException, Request, status
+from fastapi.responses import HTMLResponse, JSONResponse, StreamingResponse
 from fastapi.templating import Jinja2Templates
-from fastapi.responses import StreamingResponse
 from byoeb.background_jobs.daily_logs.asha_logs import fetch_daily_logs
 from byoeb.services.admin.message_process import process_message, clear_history
 from byoeb.chat_app.configuration.dependency_setup import media_storage
@@ -32,33 +29,24 @@ async def experiment_form_get(request: Request) -> HTMLResponse:
     return templates.TemplateResponse("admin.html", {"request": request})
 
 @admin_apis_router.post("/asha_logs")
-async def form_post(request: Request, start_datetime: str = Form(...), end_datetime: str = Form(...)) -> HTMLResponse:
-    start = datetime.strptime(start_datetime, "%Y-%m-%dT%H:%M")
-    end = datetime.strptime(end_datetime, "%Y-%m-%dT%H:%M")
-    
+async def form_post(request: Request, start: datetime = Form(...), end: datetime = Form(...)) -> HTMLResponse:
     start_unix = str(start.timestamp())
     end_unix = str(end.timestamp())
-    ashas_df = await fetch_daily_logs(
-        start_timestamp=start_unix,
-        end_timestamp=end_unix
-    )
+    ashas_df = await fetch_daily_logs(start_timestamp=start_unix, end_timestamp=end_unix)
     
     # Save to excel for download
     ashas_df.to_excel(file_path, index=False)
     blob_file_name = f"logs/{os.path.basename(file_path)}"
     # Check if file exists before deleting using aget_file_properties
-    status, _ = await media_storage.aget_file_properties(file_name=blob_file_name)
+    fileprops = await media_storage.aget_file_properties(file_name=blob_file_name)
 
     # Only delete if file exists (status 200 means file exists)
-    if status == 200:
+    if fileprops is not None:
         await media_storage.adelete_file(file_name=blob_file_name)
         print(f"Deleted existing file: {blob_file_name}")
     else:
-        print(f"File {blob_file_name} does not exist (status: {status}), skipping delete")
-    await media_storage.aupload_file(
-        file_path=file_path,
-        file_name=blob_file_name
-    )
+        print(f"File {blob_file_name} does not exist, skipping delete")
+    await media_storage.aupload_file(file_path=file_path, file_name=blob_file_name)
     # await media_storage._close()
     # Render HTML
     df_html = ashas_df.to_html(classes="table table-bordered", index=False)
@@ -70,7 +58,7 @@ async def form_post(request: Request, start_datetime: str = Form(...), end_datet
 
 @admin_apis_router.get("/download")
 async def download_excel():
-    _, asha_data = await media_storage.adownload_file(
+    asha_data = await media_storage.adownload_file(
         file_name=f"logs/{os.path.basename(file_path)}"
     )
     # await media_storage._close()

--- a/byoeb-v1/byoeb/byoeb/apis/admin.py
+++ b/byoeb-v1/byoeb/byoeb/apis/admin.py
@@ -1,13 +1,14 @@
+import csv
+import io
 import os
+from typing import AsyncIterator
 from byoeb.models.experiment import QueryInput
-from io import BytesIO
 from datetime import datetime
-from fastapi import APIRouter, Form, HTTPException, Request, status
+from fastapi import APIRouter, Form, Request
 from fastapi.responses import HTMLResponse, JSONResponse, StreamingResponse
 from fastapi.templating import Jinja2Templates
 from byoeb.background_jobs.daily_logs.asha_logs import fetch_daily_logs
 from byoeb.services.admin.message_process import process_message, clear_history
-from byoeb.chat_app.configuration.dependency_setup import media_storage
 
 REGISTER_API_NAME = 'admin_apis'
 
@@ -29,52 +30,30 @@ async def experiment_form_get(request: Request) -> HTMLResponse:
     return templates.TemplateResponse("admin.html", {"request": request})
 
 @admin_apis_router.post("/asha_logs")
-async def form_post(request: Request, start: datetime = Form(...), end: datetime = Form(...)) -> HTMLResponse:
+async def asha_logs(start: datetime = Form(...), end: datetime = Form(...)) -> StreamingResponse:
     start_unix = str(start.timestamp())
     end_unix = str(end.timestamp())
-    ashas_df = await fetch_daily_logs(start_timestamp=start_unix, end_timestamp=end_unix)
-    
-    # Save to excel for download
-    ashas_df.to_excel(file_path, index=False)
-    blob_file_name = f"logs/{os.path.basename(file_path)}"
-    # Check if file exists before deleting using aget_file_properties
-    fileprops = await media_storage.aget_file_properties(file_name=blob_file_name)
 
-    # Only delete if file exists (status 200 means file exists)
-    if fileprops is not None:
-        await media_storage.adelete_file(file_name=blob_file_name)
-        print(f"Deleted existing file: {blob_file_name}")
-    else:
-        print(f"File {blob_file_name} does not exist, skipping delete")
-    await media_storage.aupload_file(file_path=file_path, file_name=blob_file_name)
-    # await media_storage._close()
-    # Render HTML
-    df_html = ashas_df.to_html(classes="table table-bordered", index=False)
-    return templates.TemplateResponse("index.html", {
-        "request": request,
-        "table": df_html,
-        "show_download": True
+    async def stream_csv() -> AsyncIterator[bytes]:
+        buffer = io.StringIO()
+        writer = None
+
+        async for row in fetch_daily_logs(start_unix, end_unix):
+            if writer is None:
+                writer = csv.DictWriter(buffer, fieldnames=row.keys())
+                writer.writeheader()
+
+            writer.writerow(row)
+
+            chunk = buffer.getvalue()
+            buffer.seek(0)
+            buffer.truncate(0)
+
+            yield chunk.encode("utf-8")
+
+    return StreamingResponse(stream_csv(), media_type="text/csv", headers={
+        "Content-Disposition": f"attachment; filename=asha-logs-{start.isoformat()}-{end.isoformat()}.csv"
     })
-
-@admin_apis_router.get("/download")
-async def download_excel():
-    asha_data = await media_storage.adownload_file(
-        file_name=f"logs/{os.path.basename(file_path)}"
-    )
-    # await media_storage._close()
-    stream = BytesIO(asha_data.data)  # or just use Filedata if already BytesIO
-    return StreamingResponse(
-        stream,
-        media_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-        headers={
-            "Content-Disposition": "attachment; filename=downloaded.xlsx"
-        }
-    )
-    # return FileResponse(
-    #     path=file_path,
-    #     media_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-    #     filename="data.xlsx",
-    # )
 
 @admin_apis_router.post("/experiment")
 async def query_handler(input: QueryInput) -> JSONResponse:

--- a/byoeb-v1/byoeb/byoeb/apis/chat.py
+++ b/byoeb-v1/byoeb/byoeb/apis/chat.py
@@ -5,7 +5,7 @@ import time
 import uuid
 from typing import Any, List, Dict, Literal, Set
 import byoeb.chat_app.configuration.dependency_setup as dependency_setup
-from pydantic import BaseModel, Field, NonNegativeInt, PositiveInt
+from pydantic import BaseModel, Field, PositiveInt
 from byoeb_core.models.byoeb.message_context import (
     ByoebMessageContext,
     MessageContext,

--- a/byoeb-v1/byoeb/byoeb/apis/chat.py
+++ b/byoeb-v1/byoeb/byoeb/apis/chat.py
@@ -5,7 +5,7 @@ import time
 import uuid
 from typing import Any, List, Dict, Literal, Set
 import byoeb.chat_app.configuration.dependency_setup as dependency_setup
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, NonNegativeInt, PositiveInt
 from byoeb_core.models.byoeb.message_context import (
     ByoebMessageContext,
     MessageContext,
@@ -48,13 +48,14 @@ async def receive(body: Dict[str, Any] = Body(..., description="Raw WhatsApp web
 
 @chat_apis_router.get("/get_bot_messages", summary="Fetch bot messages after a given timestamp")
 async def get_bot_messages(
-    timestamp: int = Query(..., description="Unix timestamp to fetch messages since")
+    timestamp: int = Query(..., description="Unix timestamp to fetch messages since"),
+    length: PositiveInt = 1000
 ) -> List[ByoebMessageContext]:
     """
     Retrieves all bot messages stored in the database
     after the specified timestamp.
     """
-    responses = await dependency_setup.message_db_service.get_latest_bot_messages_by_timestamp(str(timestamp))
+    responses = await dependency_setup.message_db_service.get_latest_bot_messages_by_timestamp(str(timestamp), length)
     return responses
 
 

--- a/byoeb-v1/byoeb/byoeb/apis/ui_templates/index.html
+++ b/byoeb-v1/byoeb/byoeb/apis/ui_templates/index.html
@@ -6,11 +6,23 @@
     <script src="https://cdn.jsdelivr.net/npm/papaparse@5.4.1/papaparse.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js"></script>
     <style>
-        body { padding: 20px; }
-        .form-section { max-width: 720px; }
-        .results { margin-top: 30px; width: 100%; }
-        .table-wrapper { overflow-x: auto; }
-        table { width: 100%; }
+        body {
+            padding: 20px;
+        }
+        .form-section {
+            max-width: 600px;
+        }
+        .results {
+            margin-top: 30px;
+            width: 100%;
+        }
+        .table-wrapper {
+            overflow-x: auto;
+            white-space: nowrap;
+        }
+        table {
+            width: 100%;
+        }
         #status { min-height: 24px; }
     </style>
 </head>
@@ -77,7 +89,7 @@
                         endInput.value = startVal;
                     }
                 } else {
-                    endInput.min = '';
+                    endInput.min = "";
                     endInput.max = now;
                 }
             });

--- a/byoeb-v1/byoeb/byoeb/apis/ui_templates/index.html
+++ b/byoeb-v1/byoeb/byoeb/apis/ui_templates/index.html
@@ -1,81 +1,193 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>DateTime Picker</title>
+    <title>ASHA Logs</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <script src="https://cdn.jsdelivr.net/npm/papaparse@5.4.1/papaparse.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js"></script>
     <style>
-        body {
-            padding: 20px;
-        }
-        .form-section {
-            max-width: 600px;
-        }
-        .results {
-            margin-top: 30px;
-            width: 100%;
-        }
-        .table-wrapper {
-            overflow-x: auto;
-            white-space: nowrap;
-        }
-        table {
-            width: 100%;
-        }
+        body { padding: 20px; }
+        .form-section { max-width: 720px; }
+        .results { margin-top: 30px; width: 100%; }
+        .table-wrapper { overflow-x: auto; }
+        table { width: 100%; }
+        #status { min-height: 24px; }
     </style>
-    <script>
-        window.addEventListener('DOMContentLoaded', () => {
-            const now = new Date().toISOString().slice(0, 16);
-            const startInput = document.querySelector('input[name="start"]');
-            const endInput = document.querySelector('input[name="end"]');
+</head>
+<body>
+    <div class="form-section">
+        <h2 class="mb-4">ASHA Daily Logs</h2>
+        <form id="log-form" class="mb-3">
+            <div class="row g-3 align-items-end">
+                <div class="col-md-6">
+                    <label for="start" class="form-label">Start Date &amp; Time</label>
+                    <input type="datetime-local" id="start" name="start" class="form-control" required>
+                </div>
+                <div class="col-md-6">
+                    <label for="end" class="form-label">End Date &amp; Time</label>
+                    <input type="datetime-local" id="end" name="end" class="form-control" required>
+                </div>
+            </div>
+            <div class="d-flex gap-2 mt-3">
+                <button id="generate-btn" type="submit" class="btn btn-primary">Generate</button>
+                <button id="download-btn" type="button" class="btn btn-success" disabled>Download (.xlsx)</button>
+            </div>
+        </form>
+        <div id="status" class="text-muted small"></div>
+    </div>
 
+    <div class="results">
+        <div class="table-wrapper">
+            <table class="table table-striped table-sm">
+                <thead id="table-head"></thead>
+                <tbody id="table-body"></tbody>
+            </table>
+        </div>
+    </div>
+
+    <script>
+        const form = document.getElementById('log-form');
+        const startInput = document.getElementById('start');
+        const endInput = document.getElementById('end');
+        const statusEl = document.getElementById('status');
+        const tableHead = document.getElementById('table-head');
+        const tableBody = document.getElementById('table-body');
+        const downloadBtn = document.getElementById('download-btn');
+        const generateBtn = document.getElementById('generate-btn');
+
+        let headerRow = [];
+        let dataRows = [];
+        let fileName = 'asha-logs.xlsx';
+
+        function toggleLoading(isLoading) {
+            generateBtn.disabled = isLoading;
+            downloadBtn.disabled = isLoading || !headerRow.length;
+        }
+
+        function setDateBounds() {
+            const now = new Date().toISOString().slice(0, 16);
             startInput.max = now;
             endInput.max = now;
-
             startInput.addEventListener('change', () => {
                 const startVal = startInput.value;
                 if (startVal) {
                     endInput.min = startVal;
                     endInput.max = now;
-
                     if (endInput.value < startVal || endInput.value > now) {
                         endInput.value = startVal;
                     }
                 } else {
-                    endInput.min = "";
+                    endInput.min = '';
                     endInput.max = now;
                 }
             });
-        });
-    </script>
-</head>
-<body>
-    <div class="form-section">
-        <h2 class="mb-4">Select Start and End DateTime</h2>
-        <form method="post" class="mb-4">
-            <div class="mb-3">
-                <label for="start" class="form-label">Start Date & Time:</label>
-                <input type="datetime-local" name="start" class="form-control" required>
-            </div>
-            <div class="mb-3">
-                <label for="end" class="form-label">End Date & Time:</label>
-                <input type="datetime-local" name="end" class="form-control" required>
-            </div>
-            <div class="d-flex gap-2">
-                <button type="submit" class="btn btn-primary">Generate</button>
-                {% if show_download %}
-                <a href="/download" class="btn btn-success">Download</a>
-                {% endif %}
-            </div>
-        </form>
-    </div>
+        }
 
-    {% if table %}
-    <div class="results">
-        <h4>Generated Data</h4>
-        <div class="table-wrapper">
-            {{ table | safe }}
-        </div>
-    </div>
-    {% endif %}
+        function resetState() {
+            headerRow = [];
+            dataRows = [];
+            fileName = 'asha-logs.xlsx';
+            tableHead.innerHTML = '';
+            tableBody.innerHTML = '';
+            downloadBtn.disabled = true;
+        }
+
+        function renderHeader(columns) {
+            const tr = document.createElement('tr');
+            columns.forEach(col => {
+                const th = document.createElement('th');
+                th.textContent = col;
+                tr.appendChild(th);
+            });
+            tableHead.appendChild(tr);
+        }
+
+        function renderRow(values) {
+            const tr = document.createElement('tr');
+            values.forEach(value => {
+                const td = document.createElement('td');
+                td.textContent = value;
+                tr.appendChild(td);
+            });
+            tableBody.appendChild(tr);
+        }
+
+        async function fetchLogs(formData) {
+            resetState();
+            statusEl.textContent = 'Fetching logs...';
+            toggleLoading(true);
+
+            const response = await fetch('/asha_logs', {
+                method: 'POST',
+                body: formData
+            });
+
+            if (!response.ok || !response.body) {
+                statusEl.textContent = 'Failed to fetch logs.';
+                toggleLoading(false);
+                return;
+            }
+
+            const disposition = response.headers.get('content-disposition');
+            if (disposition) {
+                const match = disposition.match(/filename=([^;]+)/i);
+                if (match && match[1]) {
+                    fileName = match[1].trim().replace(/(^"|"$)/g, '').replace(/\.csv$/i, '.xlsx');
+                }
+            }
+
+            const csvText = (await response.text()).trim();
+            if (!csvText) {
+                statusEl.textContent = 'No data returned for the selected range.';
+                toggleLoading(false);
+                return;
+            }
+
+            const parsed = Papa.parse(csvText, { skipEmptyLines: true });
+            const rows = parsed.data;
+
+            if (!rows.length) {
+                statusEl.textContent = 'No rows found for the selected range.';
+                toggleLoading(false);
+                return;
+            }
+
+            headerRow = rows[0];
+            dataRows = rows.slice(1);
+            renderHeader(headerRow);
+            dataRows.forEach(renderRow);
+
+            statusEl.textContent = dataRows.length
+                ? `Loaded ${dataRows.length} rows.`
+                : 'No rows found for the selected range.';
+            downloadBtn.disabled = headerRow.length === 0;
+            toggleLoading(false);
+        }
+
+        function downloadXlsx() {
+            if (!headerRow.length) {
+                return;
+            }
+            const workbook = XLSX.utils.book_new();
+            const sheet = XLSX.utils.aoa_to_sheet([headerRow, ...dataRows]);
+            XLSX.utils.book_append_sheet(workbook, sheet, 'Logs');
+            XLSX.writeFile(workbook, fileName);
+        }
+
+        form.addEventListener('submit', async (event) => {
+            event.preventDefault();
+            const formData = new FormData(form);
+            try {
+                await fetchLogs(formData);
+            } catch (err) {
+                console.error(err);
+                statusEl.textContent = 'Error while fetching logs.';
+                toggleLoading(false);
+            }
+        });
+
+        downloadBtn.addEventListener('click', downloadXlsx);
+        window.addEventListener('DOMContentLoaded', setDateBounds);
+    </script>
 </body>
 </html>

--- a/byoeb-v1/byoeb/byoeb/apis/ui_templates/index.html
+++ b/byoeb-v1/byoeb/byoeb/apis/ui_templates/index.html
@@ -25,8 +25,8 @@
     <script>
         window.addEventListener('DOMContentLoaded', () => {
             const now = new Date().toISOString().slice(0, 16);
-            const startInput = document.querySelector('input[name="start_datetime"]');
-            const endInput = document.querySelector('input[name="end_datetime"]');
+            const startInput = document.querySelector('input[name="start"]');
+            const endInput = document.querySelector('input[name="end"]');
 
             startInput.max = now;
             endInput.max = now;
@@ -53,12 +53,12 @@
         <h2 class="mb-4">Select Start and End DateTime</h2>
         <form method="post" class="mb-4">
             <div class="mb-3">
-                <label for="start_datetime" class="form-label">Start Date & Time:</label>
-                <input type="datetime-local" name="start_datetime" class="form-control" required>
+                <label for="start" class="form-label">Start Date & Time:</label>
+                <input type="datetime-local" name="start" class="form-control" required>
             </div>
             <div class="mb-3">
-                <label for="end_datetime" class="form-label">End Date & Time:</label>
-                <input type="datetime-local" name="end_datetime" class="form-control" required>
+                <label for="end" class="form-label">End Date & Time:</label>
+                <input type="datetime-local" name="end" class="form-control" required>
             </div>
             <div class="d-flex gap-2">
                 <button type="submit" class="btn btn-primary">Generate</button>

--- a/byoeb-v1/byoeb/byoeb/background_jobs/daily_logs/asha_logs.py
+++ b/byoeb-v1/byoeb/byoeb/background_jobs/daily_logs/asha_logs.py
@@ -1,9 +1,9 @@
-import time
-import pandas as pd
+from typing import Any, AsyncIterator, Optional
 from datetime import datetime
 from byoeb.chat_app.configuration.config import app_config
 from byoeb.chat_app.configuration.dependency_setup import user_db_service
 from byoeb.factory import MongoDBFactory
+from motor.motor_asyncio import AsyncIOMotorCollection
 
 SINGLETON = "singleton"
 db_provider = app_config["app"]["db_provider"]
@@ -24,9 +24,12 @@ async def get_user_infos(batch, user_info_dict):
     return user_info_dict
 
     
-def extract_fields(entry, user_info_dict):
+def extract_fields(entry, user_info_dict) -> Optional[dict[str, Any]]:
     user = entry.get("user", {})
     user_id = user.get("user_id")
+    if user_id not in user_info_dict:
+        return None
+
     user = user_info_dict[user_id]
     message_context = entry.get("message_context", {})
     message_additional_info = message_context.get("additional_info", {})
@@ -74,59 +77,32 @@ def extract_fields(entry, user_info_dict):
         "log_date": day
     }
 
-async def fetch_and_process_user_messages(start_timestamp: str, end_timestamp: str, message_category: str, message_collection):
-    query = query = {
-        "timestamp": {
-            "$gte": start_timestamp,
-            "$lte": end_timestamp
-        },
-        "message_data.message_category": message_category
+async def fetch_and_process_user_messages(start_timestamp: str, end_timestamp: str, message_category: list[str], message_collection: AsyncIOMotorCollection) -> AsyncIterator[dict[str, Any]]:
+    query = {
+        "timestamp": {"$gte": start_timestamp, "$lte": end_timestamp},
+        "message_data.message_category": {"$in": message_category}
     }
-    cursor = message_collection.find(query)
+    cursor = message_collection.find(query).sort("incoming_timestamp", -1)
     user_info_dict = {}
-    final_df = pd.DataFrame()
     while True:
         batch = await cursor.to_list(length=1000)
         if not batch:
             break
         # Process each batch
         user_info_dict = await get_user_infos(batch, user_info_dict)
-        current_data = [extract_fields(entry['message_data'], user_info_dict) for entry in batch]
-        # Convert to DataFrame and append to final_df
-        temp_df = pd.DataFrame(current_data)
-        final_df = pd.concat([final_df, temp_df], ignore_index=True)
-    if final_df.empty:
-        return final_df
-    final_df.sort_values(by=["incoming_timestamp"], inplace=True, ascending=False, ignore_index=True)
-    return final_df
+        for entry in batch:
+            row = extract_fields(entry['message_data'], user_info_dict)
+            if row is not None:
+                yield row
 
-async def fetch_daily_logs(start_timestamp: str, end_timestamp: str):
-    mongo_db_factory = MongoDBFactory(
-        config=app_config,
-        scope=SINGLETON
-    )
+async def fetch_daily_logs(start_timestamp: str, end_timestamp: str) -> AsyncIterator[dict[str, Any]]:
+    mongo_db_factory = MongoDBFactory(config=app_config, scope=SINGLETON)
     mongo_db = await mongo_db_factory.get(db_provider)
     message_collection = mongo_db.get_collection(message_collection_name)
-    answer_df = await fetch_and_process_user_messages(
+    async for row in fetch_and_process_user_messages(
         start_timestamp=start_timestamp,
         end_timestamp=end_timestamp,
-        message_category="bot_to_asha_response",
+        message_category=["bot_to_asha_response", "audio_idk", "text_idk"],
         message_collection=message_collection
-    )
-    audio_idk_df = await fetch_and_process_user_messages(
-        start_timestamp=start_timestamp,
-        end_timestamp=end_timestamp,
-        message_category="audio_idk",
-        message_collection=message_collection
-    )
-    text_idk_df = await fetch_and_process_user_messages(
-        start_timestamp=start_timestamp,
-        end_timestamp=end_timestamp,
-        message_category="text_idk",
-        message_collection=message_collection
-    )
-    ashas_df = pd.concat([answer_df, audio_idk_df, text_idk_df], ignore_index=True)
-    if ashas_df.empty:
-        return ashas_df
-    ashas_df.sort_values(by=["incoming_timestamp"], inplace=True, ascending=False, ignore_index=True)
-    return ashas_df
+    ):
+        yield row

--- a/byoeb-v1/byoeb/byoeb/background_jobs/daily_logs/asha_logs.py
+++ b/byoeb-v1/byoeb/byoeb/background_jobs/daily_logs/asha_logs.py
@@ -82,7 +82,7 @@ async def fetch_and_process_user_messages(start_timestamp: str, end_timestamp: s
         "timestamp": {"$gte": start_timestamp, "$lte": end_timestamp},
         "message_data.message_category": {"$in": message_category}
     }
-    cursor = message_collection.find(query).sort("incoming_timestamp", -1)
+    cursor = message_collection.find(query).sort("message_data.incoming_timestamp", -1)
     user_info_dict = {}
     while True:
         batch = await cursor.to_list(length=1000)

--- a/byoeb-v1/byoeb/byoeb/services/databases/mongo_db/message_db.py
+++ b/byoeb-v1/byoeb/byoeb/services/databases/mongo_db/message_db.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 from typing import List, Dict, Any, Optional, TYPE_CHECKING
 from byoeb.factory import MongoDBFactory
 from byoeb.services.databases.mongo_db.base import BaseMongoDBService
+from pydantic import PositiveInt
 from byoeb_core.models.byoeb.message_context import ByoebMessageContext
 from collections import Counter, defaultdict
 from zoneinfo import ZoneInfo
@@ -424,11 +425,11 @@ class MessageMongoDBService(BaseMongoDBService):
         messages_obj = await message_repository.find_all({"message_data.message_context.additional_info.status": status})
         return [ByoebMessageContext(**msg_obj["message_data"]) for msg_obj in messages_obj]
 
-    async def get_latest_bot_messages_by_timestamp(self, timestamp: str):
+    async def get_latest_bot_messages_by_timestamp(self, timestamp: str, length: PositiveInt):
         """Fetch bot messages with timestamps greater than the given timestamp; preserve prior in-Python sort behavior."""
         repository_factory = await self._get_repository_factory()
         message_repository = await repository_factory.get_message_repository()
-        messages_obj = await message_repository.find_all({"timestamp": {"$gt": timestamp}})
+        messages_obj = await message_repository.find_all({"timestamp": {"$gt": timestamp}}, limit=length)
         messages_obj_sorted = sorted(messages_obj, key=lambda msg: msg.get("timestamp"), reverse=True)
         return [ByoebMessageContext(**msg_obj["message_data"]) for msg_obj in messages_obj_sorted]
 

--- a/byoeb-v1/byoeb/tests/integration/apis/test_admin.py
+++ b/byoeb-v1/byoeb/tests/integration/apis/test_admin.py
@@ -17,7 +17,7 @@ def _format(dt: datetime) -> str:
 def test_post_asha_logs_returns_html_and_download_link():
     now = datetime.now(timezone.utc)
     start = now - timedelta(minutes=30)
-    response = requests.post(ASHA_LOGS_URL, data={"start_datetime": _format(start), "end_datetime": _format(now)})
+    response = requests.post(ASHA_LOGS_URL, data={"start": _format(start), "end": _format(now)})
     response.raise_for_status()
     assert response.headers.get("content-type", "").startswith("text/html")
     assert "<table" in response.text
@@ -25,23 +25,23 @@ def test_post_asha_logs_returns_html_and_download_link():
 
 def test_post_asha_logs_requires_end_datetime():
     now = datetime.now(timezone.utc)
-    response = requests.post(ASHA_LOGS_URL, data={"start_datetime": _format(now - timedelta(minutes=15))})
+    response = requests.post(ASHA_LOGS_URL, data={"start": _format(now - timedelta(minutes=15))})
     assert response.status_code == 422
     detail = response.json().get("detail", [])
-    assert any(item.get("loc", [None])[-1] == "end_datetime" for item in detail)
+    assert any(item.get("loc", [None])[-1] == "end" for item in detail)
 
 
 def test_post_asha_logs_requires_start_datetime():
     now = datetime.now(timezone.utc)
-    response = requests.post(ASHA_LOGS_URL, data={"end_datetime": _format(now)})
+    response = requests.post(ASHA_LOGS_URL, data={"end": _format(now)})
     assert response.status_code == 422
     detail = response.json().get("detail", [])
-    assert any(item.get("loc", [None])[-1] == "start_datetime" for item in detail)
+    assert any(item.get("loc", [None])[-1] == "start" for item in detail)
 
 
 def test_post_asha_logs_rejects_invalid_datetime_format():
     now = datetime.now(timezone.utc)
-    response = requests.post(ASHA_LOGS_URL, data={"start_datetime": "not-a-date", "end_datetime": _format(now)})
+    response = requests.post(ASHA_LOGS_URL, data={"start": "not-a-date", "end": _format(now)})
     assert response.status_code == 422
     detail = response.json().get("detail", [])
-    assert any(item.get("loc", [None])[-1] == "start_datetime" for item in detail)
+    assert any(item.get("loc", [None])[-1] == "start" for item in detail)

--- a/byoeb-v1/byoeb/tests/integration/apis/test_admin.py
+++ b/byoeb-v1/byoeb/tests/integration/apis/test_admin.py
@@ -1,0 +1,47 @@
+import os
+from datetime import datetime, timedelta, timezone
+
+import requests
+
+
+BASE_URL = os.getenv("RECIEVE_URL")
+if not BASE_URL:
+    raise RuntimeError("Environment variable (RECIEVE_URL) is missing")
+ASHA_LOGS_URL = f"{BASE_URL.replace('/receive', '').rstrip('/')}/asha_logs"
+
+
+def _format(dt: datetime) -> str:
+    return dt.strftime("%Y-%m-%dT%H:%M")
+
+
+def test_post_asha_logs_returns_html_and_download_link():
+    now = datetime.now(timezone.utc)
+    start = now - timedelta(minutes=30)
+    response = requests.post(ASHA_LOGS_URL, data={"start_datetime": _format(start), "end_datetime": _format(now)})
+    response.raise_for_status()
+    assert response.headers.get("content-type", "").startswith("text/html")
+    assert "<table" in response.text
+
+
+def test_post_asha_logs_requires_end_datetime():
+    now = datetime.now(timezone.utc)
+    response = requests.post(ASHA_LOGS_URL, data={"start_datetime": _format(now - timedelta(minutes=15))})
+    assert response.status_code == 422
+    detail = response.json().get("detail", [])
+    assert any(item.get("loc", [None])[-1] == "end_datetime" for item in detail)
+
+
+def test_post_asha_logs_requires_start_datetime():
+    now = datetime.now(timezone.utc)
+    response = requests.post(ASHA_LOGS_URL, data={"end_datetime": _format(now)})
+    assert response.status_code == 422
+    detail = response.json().get("detail", [])
+    assert any(item.get("loc", [None])[-1] == "start_datetime" for item in detail)
+
+
+def test_post_asha_logs_rejects_invalid_datetime_format():
+    now = datetime.now(timezone.utc)
+    response = requests.post(ASHA_LOGS_URL, data={"start_datetime": "not-a-date", "end_datetime": _format(now)})
+    assert response.status_code == 422
+    detail = response.json().get("detail", [])
+    assert any(item.get("loc", [None])[-1] == "start_datetime" for item in detail)

--- a/byoeb-v1/byoeb/tests/integration/apis/test_admin.py
+++ b/byoeb-v1/byoeb/tests/integration/apis/test_admin.py
@@ -1,13 +1,17 @@
+import csv
+import io
 import os
 from datetime import datetime, timedelta, timezone
 
+import pytest
 import requests
 
 
 BASE_URL = os.getenv("RECIEVE_URL")
 if not BASE_URL:
     raise RuntimeError("Environment variable (RECIEVE_URL) is missing")
-ASHA_LOGS_URL = f"{BASE_URL.replace('/receive', '').rstrip('/')}/asha_logs"
+BASE_URL = BASE_URL.replace('/receive', '')
+ASHA_LOGS_URL = f"{BASE_URL}/asha_logs"
 
 
 def test_post_asha_logs_streams_csv_with_attachment_header():
@@ -43,3 +47,47 @@ def test_post_asha_logs_rejects_invalid_datetime_format():
     assert response.status_code == 422
     detail = response.json().get("detail", [])
     assert any(item.get("loc", [None])[-1] == "start" for item in detail)
+
+
+def test_post_asha_logs_stream_is_parsable_and_sorted():
+    bot_messages_url = f"{BASE_URL}/get_bot_messages"
+    bot_response = requests.get(bot_messages_url, params={"timestamp": 0, "length": 100})
+    bot_response.raise_for_status()
+    bot_messages = bot_response.json()
+    if not bot_messages:
+        pytest.skip("No bot messages available to test asha logs streaming response")
+
+    incoming_timestamps = []
+    for message in bot_messages:
+        incoming_ts = message.get("incoming_timestamp")
+        if incoming_ts in (None, "", "None"):
+            continue
+        try:
+            incoming_timestamps.append(int(incoming_ts))
+        except (TypeError, ValueError):
+            continue
+
+    if not incoming_timestamps:
+        pytest.skip("Bot messages do not contain usable incoming timestamps")
+
+    start = datetime.fromtimestamp(min(incoming_timestamps), tz=timezone.utc)
+    end = min(
+        datetime.fromtimestamp(max(incoming_timestamps), tz=timezone.utc),
+        datetime.now(timezone.utc) - timedelta(seconds=1)
+    )
+
+    response = requests.post(ASHA_LOGS_URL, data={"start": start.isoformat(), "end": end.isoformat()})
+    response.raise_for_status()
+
+    reader = csv.DictReader(io.StringIO(response.content.decode()))
+    rows = list(reader)
+
+    if not rows:
+        pytest.skip("Asha logs streamed response returned no rows")
+
+    first_row = rows[0]
+    for field in ("phone_number_id", "query_source", "answer_source"):
+        assert field in first_row and first_row[field] != ""
+
+    incoming_timestamp_values = [int(row["incoming_timestamp"]) for row in rows if row.get("incoming_timestamp")]
+    assert incoming_timestamp_values == sorted(incoming_timestamp_values, reverse=True)

--- a/byoeb-v1/byoeb/tests/integration/apis/test_admin.py
+++ b/byoeb-v1/byoeb/tests/integration/apis/test_admin.py
@@ -10,13 +10,15 @@ if not BASE_URL:
 ASHA_LOGS_URL = f"{BASE_URL.replace('/receive', '').rstrip('/')}/asha_logs"
 
 
-def test_post_asha_logs_returns_html_and_download_link():
+def test_post_asha_logs_streams_csv_with_attachment_header():
     now = datetime.now(timezone.utc)
     start = now - timedelta(minutes=30)
     response = requests.post(ASHA_LOGS_URL, data={"start": start.isoformat(), "end": now.isoformat()})
     response.raise_for_status()
-    assert response.headers.get("content-type", "").startswith("text/html")
-    assert "<table" in response.text
+    assert response.headers.get("content-type", "").startswith("text/csv")
+    content_disposition = response.headers.get("content-disposition", "")
+    assert "attachment;" in content_disposition
+    assert "asha-logs" in content_disposition
 
 
 def test_post_asha_logs_requires_end_datetime():

--- a/byoeb-v1/byoeb/tests/integration/apis/test_admin.py
+++ b/byoeb-v1/byoeb/tests/integration/apis/test_admin.py
@@ -10,14 +10,10 @@ if not BASE_URL:
 ASHA_LOGS_URL = f"{BASE_URL.replace('/receive', '').rstrip('/')}/asha_logs"
 
 
-def _format(dt: datetime) -> str:
-    return dt.strftime("%Y-%m-%dT%H:%M")
-
-
 def test_post_asha_logs_returns_html_and_download_link():
     now = datetime.now(timezone.utc)
     start = now - timedelta(minutes=30)
-    response = requests.post(ASHA_LOGS_URL, data={"start": _format(start), "end": _format(now)})
+    response = requests.post(ASHA_LOGS_URL, data={"start": start.isoformat(), "end": now.isoformat()})
     response.raise_for_status()
     assert response.headers.get("content-type", "").startswith("text/html")
     assert "<table" in response.text
@@ -25,7 +21,7 @@ def test_post_asha_logs_returns_html_and_download_link():
 
 def test_post_asha_logs_requires_end_datetime():
     now = datetime.now(timezone.utc)
-    response = requests.post(ASHA_LOGS_URL, data={"start": _format(now - timedelta(minutes=15))})
+    response = requests.post(ASHA_LOGS_URL, data={"start": (now - timedelta(minutes=15)).isoformat()})
     assert response.status_code == 422
     detail = response.json().get("detail", [])
     assert any(item.get("loc", [None])[-1] == "end" for item in detail)
@@ -33,7 +29,7 @@ def test_post_asha_logs_requires_end_datetime():
 
 def test_post_asha_logs_requires_start_datetime():
     now = datetime.now(timezone.utc)
-    response = requests.post(ASHA_LOGS_URL, data={"end": _format(now)})
+    response = requests.post(ASHA_LOGS_URL, data={"end": now.isoformat()})
     assert response.status_code == 422
     detail = response.json().get("detail", [])
     assert any(item.get("loc", [None])[-1] == "start" for item in detail)
@@ -41,7 +37,7 @@ def test_post_asha_logs_requires_start_datetime():
 
 def test_post_asha_logs_rejects_invalid_datetime_format():
     now = datetime.now(timezone.utc)
-    response = requests.post(ASHA_LOGS_URL, data={"start": "not-a-date", "end": _format(now)})
+    response = requests.post(ASHA_LOGS_URL, data={"start": "not-a-date", "end": now.isoformat()})
     assert response.status_code == 422
     detail = response.json().get("detail", [])
     assert any(item.get("loc", [None])[-1] == "start" for item in detail)


### PR DESCRIPTION
## Introduction
After [Release 2025.12.01](https://github.com/A4i-tech/byoeb/pull/91), POST /asha_logs returns 500 from outdated code. Existing implementation also included XLSX-generation (not suitable choice for data streaming), blob-storage steps in between, manual datetime parsing rules, and a separate download route despite `/asha_logs` already exporting logs (just in HTML format).

Changes in this PR address these issues. The change is live on staging: https://byoeb-a4i-main-cd-1.onrender.com/asha_logs

## Changes
- Fix `/asha_logs` returning 500 error despite correct inputs
- Add integration tests to ensure `/asha_logs` works as expected. Integration tests...
  - ensure start and end dates are mandatory fields and in proper format
  - ensure CSV is streamed with correct content-type and content-disposition
  - ensure requests with missing start or end return 422 with proper field errors
  - ensure invalid datetime formats are rejected
  - ensure streamed CSV is parsable and includes required fields (phone_number_id, query_source, answer_source)
  - ensure rows are sorted by incoming_timestamp in descending order
- Update `/asha_logs` endpoint to...
  - accept ISO-formatted start/end date inputs
  - return CSV instead of XLSX - CSV supports line-by-line transmission which makes it suitable for efficient streaming. Client-side performs CSV -> XLSX conversion.
  - return a streaming response using buffered database values instead of storing temporary files in Azure blob storage
- Delete unused `/download` endpoint (which downloaded asha logs XLSX previously prepared by /asha_logs)
- `/get_bot_messages` now accepts a `limit=1000` parameter
  `?timestamp=0&limit=100` is used in integration tests to fetch a sample of messages to setup `start`/`end` dates for `/asha_logs`