### PR TITLE
background-jobs: deprecate POST /schedule endpoint

### DIFF
--- a/byoeb-v1/byoeb/byoeb/apis/background_jobs.py
+++ b/byoeb-v1/byoeb/byoeb/apis/background_jobs.py
@@ -5,7 +5,7 @@ from zoneinfo import ZoneInfo
 from typing import Any, Awaitable, Callable, Dict, List, Optional
 from byoeb.application_logger.azure_app_insights import AppInsightsLogHandler
 
-from fastapi import APIRouter, Path, Response, status
+from fastapi import APIRouter, Path, status
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 from apscheduler.triggers.cron import BaseTrigger, CronTrigger
@@ -137,8 +137,8 @@ def setup_scheduled_jobs():
 # API Endpoints
 # ---------------------------------------------------------
 @background_apis_router.post("/schedule", deprecated=True)
-async def __schedule() -> Response:
-    return Response(status_code=299, content="This endpoint has been deprecated, use POST /jobs/{job_id} instead.")
+async def __schedule() -> JSONResponse:
+    return JSONResponse(status_code=status.HTTP_200_OK, content={"detail": "This endpoint has been deprecated, use POST /jobs/{job_id} instead."})
 
 @background_apis_router.post("/jobs/{job_id}", summary="Run a background job manually")
 async def run_job_manually(job_id: str = Path(..., description="Job ID to trigger")) -> JSONResponse:

--- a/byoeb-v1/byoeb/byoeb/apis/background_jobs.py
+++ b/byoeb-v1/byoeb/byoeb/apis/background_jobs.py
@@ -5,7 +5,7 @@ from zoneinfo import ZoneInfo
 from typing import Any, Awaitable, Callable, Dict, List, Optional
 from byoeb.application_logger.azure_app_insights import AppInsightsLogHandler
 
-from fastapi import APIRouter, Path, status
+from fastapi import APIRouter, Path, Response, status
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 from apscheduler.triggers.cron import BaseTrigger, CronTrigger
@@ -136,6 +136,10 @@ def setup_scheduled_jobs():
 # ---------------------------------------------------------
 # API Endpoints
 # ---------------------------------------------------------
+@background_apis_router.post("/schedule", deprecated=True)
+async def __schedule() -> Response:
+    return Response(status_code=299, content="This endpoint has been deprecated, use POST /jobs/{job_id} instead.")
+
 @background_apis_router.post("/jobs/{job_id}", summary="Run a background job manually")
 async def run_job_manually(job_id: str = Path(..., description="Job ID to trigger")) -> JSONResponse:
     """


### PR DESCRIPTION
## Introduction
Old `POST /schedule` endpoint is still being hit by an internal cron task and surfacing as 404s in Azure App Insights:
<img alt="image" src="https://github.com/user-attachments/assets/bc156927-5ff8-498f-914f-bdd8c3ed6f39" />


To prevent this noise while we phase out the endpoint, it is now explicitly marked deprecated and return 299.

## Changes
- Add deprecate `POST /schedule` endpoint with `deprecated=True` and a fixed 299 response
  <img alt="image" src="https://github.com/user-attachments/assets/8fa8ae8a-3987-4b9d-82b9-bcd2dc01788f" />
