### PR TITLE
whatsapp: downgrade interactive message to text message if it has no actions

### DIFF
--- a/byoeb-v1/byoeb/byoeb/services/chat/utils.py
+++ b/byoeb-v1/byoeb/byoeb/services/chat/utils.py
@@ -20,7 +20,8 @@ def has_interactive_list_additional_info(
     return (
         byoeb_message.message_context.additional_info is not None and
         constants.DESCRIPTION in byoeb_message.message_context.additional_info and
-        constants.ROW_TEXTS in byoeb_message.message_context.additional_info
+        constants.ROW_TEXTS in byoeb_message.message_context.additional_info and
+        byoeb_message.message_context.additional_info[constants.ROW_TEXTS]
     )
 
 def has_interactive_button_additional_info(


### PR DESCRIPTION
## Introduction
Text messages do not show on mobile for Marathi users but appear on WhatsApp Web. This happens when we send interactive lists with no items.

## Changes
- Add check to reject empty interactive lists in `has_interactive_list_additional_info`