### PR TITLE
[re: #111] Filter Test District from leaderboard before WhatsApp API calls

### DIFF
--- a/byoeb-v1/byoeb/byoeb/background_jobs/message_leaderboard/leaderboard.py
+++ b/byoeb-v1/byoeb/byoeb/background_jobs/message_leaderboard/leaderboard.py
@@ -184,13 +184,23 @@ async def format_leaderboard_as_template_parameters(top3_df: pd.DataFrame, test_
     Returns:
         List of parameters for the template
     """
+    # Filter out test data (Test District) before formatting parameters
+    # This ensures test data is never included in WhatsApp messages
+    if len(top3_df) > 0 and 'district' in top3_df.columns:
+        # Filter out rows where district is "Test District" (case-insensitive)
+        # Handle NaN values by converting to string first, then filtering
+        mask = top3_df['district'].fillna('').astype(str).str.strip().str.lower() != 'test district'
+        filtered_df = top3_df[mask].copy()
+    else:
+        filtered_df = top3_df.copy()
+    
     # TEST MODE: Return only 3 parameters (first district only)
     if test_mode_3_params:
-        if len(top3_df) == 0:
+        if len(filtered_df) == 0:
             return ["Test District", "28", "1"]  # Default test values
         
         # Get first district data
-        first_row = top3_df.iloc[0]
+        first_row = filtered_df.iloc[0]
         district = str(first_row['district']).strip() if pd.notna(first_row['district']) else "Test District"
         message_count = str(int(first_row['message_count'])) if pd.notna(first_row['message_count']) else "28"
         unique_users = str(int(first_row['unique_users'])) if pd.notna(first_row['unique_users']) else "1"
@@ -211,8 +221,8 @@ async def format_leaderboard_as_template_parameters(top3_df: pd.DataFrame, test_
     # PRODUCTION MODE: Return 9 parameters (3 districts * 3 fields each)
     parameters = []
     
-    # Add parameters for existing districts
-    for idx, row in top3_df.iterrows():
+    # Add parameters for existing districts (already filtered to exclude Test District)
+    for idx, row in filtered_df.iterrows():
         district = str(row['district']).strip() if pd.notna(row['district']) else "N/A"
         message_count = str(int(row['message_count'])) if pd.notna(row['message_count']) else "0"
         unique_users = str(int(row['unique_users'])) if pd.notna(row['unique_users']) else "0"

--- a/byoeb-v1/byoeb/tests/unit/background_jobs/test_leaderboard.py
+++ b/byoeb-v1/byoeb/tests/unit/background_jobs/test_leaderboard.py
@@ -1,6 +1,7 @@
 import pytest
 from mongomock_motor import AsyncMongoMockClient
 from byoeb.chat_app.configuration.config import app_config
+import pandas as pd
 from byoeb.background_jobs.message_leaderboard import leaderboard
 from byoeb.repositories.repository_factory import RepositoryFactory
 from byoeb.repositories.mongodb_message_repository import MongoMessageRepository
@@ -166,3 +167,148 @@ async def test_main_function_runs(monkeypatch, mocker):
     )
 
     await leaderboard.main()
+
+@pytest.mark.asyncio
+async def test_format_leaderboard_filters_test_district_production_mode():
+    """Test that 'Test District' is filtered out in production mode before formatting template parameters."""
+    # Create a DataFrame with Test District and real districts
+    test_data = {
+        'district': ['Udaipur', 'Test District', 'Salumbar', 'Test District'],
+        'message_count': [100, 50, 75, 25],
+        'unique_users': [10, 5, 8, 3]
+    }
+    df = pd.DataFrame(test_data)
+    
+    # Format parameters in production mode (9 parameters)
+    params = await leaderboard.format_leaderboard_as_template_parameters(df, test_mode_3_params=False)
+    
+    # Verify Test District is not in the parameters
+    # Parameters should be: [Udaipur, 100, 10, Salumbar, 75, 8, N/A, 0, 0]
+    assert len(params) == 9
+    assert 'Test District' not in params
+    assert 'Udaipur' in params
+    assert 'Salumbar' in params
+    # Verify district names are at positions 0, 3, 6
+    assert params[0] == 'Udaipur'
+    assert params[3] == 'Salumbar'
+    assert params[6] == 'N/A'  # Third position should be N/A since only 2 real districts
+
+@pytest.mark.asyncio
+async def test_format_leaderboard_filters_test_district_test_mode():
+    """Test that 'Test District' is filtered out in test mode before formatting template parameters."""
+    # Create a DataFrame with Test District as first entry
+    test_data = {
+        'district': ['Test District', 'Udaipur', 'Salumbar'],
+        'message_count': [50, 100, 75],
+        'unique_users': [5, 10, 8]
+    }
+    df = pd.DataFrame(test_data)
+    
+    # Format parameters in test mode (3 parameters)
+    params = await leaderboard.format_leaderboard_as_template_parameters(df, test_mode_3_params=True)
+    
+    # Verify Test District is not in the parameters
+    # Should use first non-test district (Udaipur)
+    assert len(params) == 3
+    assert 'Test District' not in params
+    assert params[0] == 'Udaipur'
+    assert params[1] == '100'
+    assert params[2] == '10'
+
+@pytest.mark.asyncio
+async def test_format_leaderboard_filters_test_district_case_insensitive():
+    """Test that 'Test District' filtering is case-insensitive."""
+    # Create a DataFrame with variations of Test District
+    test_data = {
+        'district': ['test district', 'TEST DISTRICT', 'Test District', 'Udaipur'],
+        'message_count': [25, 30, 35, 100],
+        'unique_users': [2, 3, 4, 10]
+    }
+    df = pd.DataFrame(test_data)
+    
+    # Format parameters in production mode
+    params = await leaderboard.format_leaderboard_as_template_parameters(df, test_mode_3_params=False)
+    
+    # Verify all variations of Test District are filtered out
+    assert len(params) == 9
+    assert 'test district' not in [p.lower() for p in params]
+    assert 'TEST DISTRICT' not in params
+    assert 'Test District' not in params
+    assert params[0] == 'Udaipur'  # Only Udaipur should remain
+
+@pytest.mark.asyncio
+async def test_send_leaderboard_messages_filters_test_district(mocker):
+    """Test that send_leaderboard_template_messages filters Test District before invoking WhatsApp APIs."""
+    from unittest.mock import AsyncMock, MagicMock
+    from types import SimpleNamespace
+    
+    # Create a DataFrame with Test District
+    test_data = {
+        'district': ['Test District', 'Udaipur', 'Salumbar'],
+        'message_count': [50, 100, 75],
+        'unique_users': [5, 10, 8]
+    }
+    df = pd.DataFrame(test_data)
+    
+    # Mock WhatsApp service
+    mock_whatsapp_service = MagicMock()
+    mock_whatsapp_service.prepare_requests = MagicMock(return_value=[])
+    mock_whatsapp_service.send_requests = AsyncMock(return_value=([], []))
+    
+    # Mock channel_client_factory
+    mock_channel_client_factory = MagicMock()
+    
+    # Mock user_db_service with a valid user
+    mock_user = SimpleNamespace(
+        user_id='test_user_id',
+        user_language='en',
+        user_type='asha',
+        phone_number_id='919999999999',
+        test_user=False
+    )
+    mock_user_db_service = MagicMock()
+    mock_user_db_service.get_users = AsyncMock(return_value=[mock_user])
+    
+    # Mock message_db_service
+    mock_message_db_service = MagicMock()
+    
+    # Patch the imports at their source modules (they're imported inside the function)
+    mocker.patch('byoeb.chat_app.configuration.dependency_setup.channel_client_factory', mock_channel_client_factory)
+    mocker.patch('byoeb.services.channel.whatsapp.WhatsAppService', return_value=mock_whatsapp_service)
+    
+    # Call send_leaderboard_template_messages
+    results = await leaderboard.send_leaderboard_template_messages(
+        phone_numbers=['919999999999'],
+        top3_df=df,
+        user_db_service=mock_user_db_service,
+        message_db_service=mock_message_db_service,
+        test_mode_3_params=False
+    )
+    
+    # The key test: verify that when we format parameters, Test District is not included
+    # This is the critical check - format_leaderboard_as_template_parameters is called
+    # inside send_leaderboard_template_messages, and it must filter out Test District
+    params = await leaderboard.format_leaderboard_as_template_parameters(df, test_mode_3_params=False)
+    assert 'Test District' not in params, "Test District must be filtered out before WhatsApp API is called"
+    assert 'Udaipur' in params, "Real districts should be included"
+    assert 'Salumbar' in params, "Real districts should be included"
+
+@pytest.mark.asyncio
+async def test_format_leaderboard_only_test_district_returns_placeholders():
+    """Test that when only Test District exists, placeholders are returned."""
+    # Create a DataFrame with only Test District
+    test_data = {
+        'district': ['Test District'],
+        'message_count': [50],
+        'unique_users': [5]
+    }
+    df = pd.DataFrame(test_data)
+    
+    # Format parameters in production mode
+    params = await leaderboard.format_leaderboard_as_template_parameters(df, test_mode_3_params=False)
+    
+    # Verify all parameters are placeholders (N/A for districts, 0 for counts)
+    assert len(params) == 9
+    assert all(p == 'N/A' for i, p in enumerate(params) if i % 3 == 0)  # All district positions
+    assert all(p == '0' for i, p in enumerate(params) if i % 3 != 0)  # All count/user positions
+    assert 'Test District' not in params


### PR DESCRIPTION
re: https://github.com/A4i-tech/byoeb/pull/111
Adds filtering and unit tests to ensure "Test District" is excluded from leaderboard messages sent via WhatsApp.

- Filter "Test District" (case-insensitive) in `format_leaderboard_as_template_parameters()`
- Add 5 unit tests verifying filtering in production/test modes