### PR TITLE
feat: Add personalized district/block leaderboards with multi-language support

### DIFF
--- a/byoeb-v1/byoeb/byoeb/background_jobs/message_leaderboard/leaderboard.py
+++ b/byoeb-v1/byoeb/byoeb/background_jobs/message_leaderboard/leaderboard.py
@@ -22,7 +22,7 @@ send_logger = AppInsightsLogHandler.getLogger("leaderboard_send")
 
 # TEST MODE: Set to True to send only to your test phone number
 # Set to False to send to all users (production mode)
-TEST_MODE_SEND_TO_ME_ONLY = False  # Set to True for testing, False for production
+TEST_MODE_SEND_TO_ME_ONLY = True  # Set to True for testing, False for production
 
 # Your test phone number (read from keys.env using PHONE_NUMBER_ID)
 TEST_PHONE_NUMBER = os.getenv("PHONE_NUMBER_ID") if TEST_MODE_SEND_TO_ME_ONLY else None
@@ -196,6 +196,124 @@ async def build_custom_leaderboard(days_back: int, message_categories: Optional[
     """
     return await build_district_leaderboard_with_strategy('custom', message_categories, processing_batch_size, days_back=days_back)
 
+async def build_all_block_leaderboards(
+    message_categories: Optional[List[str]] = None,
+    processing_batch_size: int = 1000
+) -> Dict[str, pd.DataFrame]:
+    """
+    Builds block leaderboards for ALL districts in a single pass for optimal performance.
+    
+    This function fetches messages and hydrates users once, then computes block leaderboards
+    for all districts in a single pass, avoiding redundant database queries.
+    
+    Args:
+        message_categories: Optional list of message categories to filter by
+        processing_batch_size: Number of documents to process in each batch
+        
+    Returns:
+        Dict[str, pd.DataFrame]: Dictionary mapping district (normalized, lowercase) to block leaderboard DataFrame
+    """
+    week_strategy = TimeWindowFactory.create_strategy('week')
+    start_timestamp, end_timestamp = week_strategy.calculate_window()
+    
+    # Get repository instances from message_db_service
+    repository_factory = await message_db_service._get_repository_factory()
+    message_repository = await repository_factory.get_message_repository()
+    
+    # Define projection for required fields only
+    required_fields_only = {"_id": 0, "message_data.user.user_id": 1, "message_data.incoming_timestamp": 1}
+    
+    # Sort by timestamp descending in database for better performance
+    sort_by_timestamp = [("message_data.incoming_timestamp", -1)]
+    
+    # Get messages using repository with database-level sorting - FETCH ONCE
+    message_iterator = await message_repository.find_messages_by_time_range(
+        start_timestamp=start_timestamp,
+        end_timestamp=end_timestamp,
+        message_categories=message_categories,
+        projection=required_fields_only,
+        sort=sort_by_timestamp
+    )
+    message_documents = [doc async for doc in message_iterator]
+    
+    if not user_db_service:
+        raise ValueError("user_db_service must be provided for leaderboard functionality")
+    
+    # HYDRATE USERS ONCE for all messages
+    user_objects_cache = {}
+    if message_documents:
+        await user_db_service.hydrate_users(message_documents, user_objects_cache)
+    
+    # Initialize counters for all districts: district -> block -> stats
+    # Structure: {district: {block: {message_count, unique_users, first_seen, last_seen}}}
+    district_block_stats = defaultdict(lambda: defaultdict(lambda: {
+        "message_count": 0,
+        "unique_users": set(),
+        "first_seen": None,
+        "last_seen": None
+    }))
+    
+    # Process all messages in a single pass
+    for message_document in message_documents:
+        message_data = message_document.get("message_data", {})
+        user_id = message_data.get("user", {}).get("user_id")
+        message_timestamp = message_data.get("incoming_timestamp")
+        
+        if not isinstance(message_timestamp, int) or message_timestamp < start_timestamp or message_timestamp > end_timestamp:
+            continue
+        
+        user_object = user_objects_cache.get(user_id)
+        user_district = get_user_district(user_object)
+        user_block = get_user_block(user_object)
+        
+        # Only process if user has both district and block info
+        if not user_district or not user_block:
+            continue
+        
+        # Normalize district name for comparison (case-insensitive)
+        district_normalized = user_district.strip().lower()
+        block_normalized = user_block.strip()
+        
+        # Update stats for this district-block combination
+        stats = district_block_stats[district_normalized][block_normalized]
+        stats["message_count"] += 1
+        if user_id:
+            stats["unique_users"].add(user_id)
+        
+        if stats["first_seen"] is None or message_timestamp < stats["first_seen"]:
+            stats["first_seen"] = message_timestamp
+        if stats["last_seen"] is None or message_timestamp > stats["last_seen"]:
+            stats["last_seen"] = message_timestamp
+    
+    # Convert aggregated stats to DataFrames for each district
+    district_block_leaderboards = {}
+    for district, block_stats in district_block_stats.items():
+        leaderboard_rows = [
+            {
+                "block": block_name,
+                "message_count": stats["message_count"],
+                "unique_users": len(stats["unique_users"]),
+                "first_seen": datetime.fromtimestamp(stats["first_seen"]).strftime("%d-%m-%Y %H:%M:%S") if stats["first_seen"] else None,
+                "last_seen": datetime.fromtimestamp(stats["last_seen"]).strftime("%d-%m-%Y %H:%M:%S") if stats["last_seen"] else None
+            }
+            for block_name, stats in block_stats.items()
+        ]
+        
+        if not leaderboard_rows:
+            district_block_leaderboards[district] = pd.DataFrame(
+                columns=["block", "message_count", "unique_users", "first_seen", "last_seen"]
+            )
+        else:
+            # Sort by message_count and unique_users, then take top 3
+            df = pd.DataFrame(leaderboard_rows).sort_values(
+                by=["message_count", "unique_users"], 
+                ascending=False, 
+                ignore_index=True
+            )
+            district_block_leaderboards[district] = df.head(3)
+    
+    return district_block_leaderboards
+
 async def build_block_leaderboard_for_district(
     district: str,
     message_categories: Optional[List[str]] = None,
@@ -222,17 +340,18 @@ async def build_block_leaderboard_for_district(
     # Define projection for required fields only
     required_fields_only = {"_id": 0, "message_data.user.user_id": 1, "message_data.incoming_timestamp": 1}
     
-    # Get messages using repository
+    # Sort by timestamp descending in database for better performance
+    sort_by_timestamp = [("message_data.incoming_timestamp", -1)]
+    
+    # Get messages using repository with database-level sorting
     message_iterator = await message_repository.find_messages_by_time_range(
         start_timestamp=start_timestamp,
         end_timestamp=end_timestamp,
         message_categories=message_categories,
-        projection=required_fields_only
+        projection=required_fields_only,
+        sort=sort_by_timestamp
     )
     message_documents = [doc async for doc in message_iterator]
-    
-    # Sort messages by timestamp (descending)
-    message_documents.sort(key=lambda x: x.get("message_data", {}).get("incoming_timestamp", 0), reverse=True)
     
     if not user_db_service:
         raise ValueError("user_db_service must be provided for leaderboard functionality")
@@ -388,51 +507,58 @@ async def send_leaderboard_template_messages(
     users = await user_db_service.get_users(user_ids)
     user_map = {user.phone_number_id: user for user in users if user}
     
-    # Pre-calculate block leaderboards for all unique districts to avoid recalculating
-    # This is much more efficient than calculating for each user individually
-    unique_districts = set()
-    for user in users:
-        if user and has_location_info(user):
-            district = get_user_district(user)
-            if district:
-                unique_districts.add(district.strip().lower())
-    
-    print(f"\n📊 Pre-calculating block leaderboards for {len(unique_districts)} districts...")
+    # Pre-calculate block leaderboards for all districts in a single optimized pass
+    # This fetches messages and hydrates users once, then computes all district block leaderboards
+    print(f"\n📊 Pre-calculating block leaderboards for all districts in a single pass...")
     run_logger.info("Pre-calculating block leaderboards", extra={AppInsightsLogHandler.DETAILS: {
-        "context": "pre_calculate_block_leaderboards",
-        "unique_districts_count": len(unique_districts),
-        "districts": list(unique_districts)
+        "context": "pre_calculate_block_leaderboards_optimized"
     }})
     
-    block_leaderboard_cache = {}
-    for district in unique_districts:
-        try:
-            block_df = await build_block_leaderboard_for_district(
-                district=district,
-                message_categories=None,
-                processing_batch_size=1000
-            )
-            block_leaderboard_cache[district] = block_df
-            run_logger.info(f"Block leaderboard calculated for district", extra={AppInsightsLogHandler.DETAILS: {
-                "context": "build_block_leaderboard",
-                "district": district,
-                "blocks_found": len(block_df)
-            }})
-        except Exception as e:
-            block_leaderboard_cache[district] = None  # Cache None to avoid retrying
-            run_logger.error(f"Error building block leaderboard for district", extra={AppInsightsLogHandler.DETAILS: {
-                "context": "build_block_leaderboard_error",
-                "district": district,
-                "error": str(e)
-            }})
-    
-    successful_districts = len([v for v in block_leaderboard_cache.values() if v is not None])
-    print(f"   ✅ Calculated {successful_districts}/{len(unique_districts)} district block leaderboards")
-    run_logger.info("Block leaderboard cache ready", extra={AppInsightsLogHandler.DETAILS: {
-        "context": "block_leaderboard_cache_ready",
-        "successful_districts": successful_districts,
-        "total_districts": len(unique_districts)
-    }})
+    try:
+        # Build all block leaderboards in a single pass - much more efficient!
+        all_block_leaderboards = await build_all_block_leaderboards(
+            message_categories=None,
+            processing_batch_size=1000
+        )
+        
+        # Extract unique districts from users for logging
+        unique_districts = set()
+        for user in users:
+            if user and has_location_info(user):
+                district = get_user_district(user)
+                if district:
+                    unique_districts.add(district.strip().lower())
+        
+        # Create cache from the optimized results
+        block_leaderboard_cache = {}
+        for district in unique_districts:
+            block_df = all_block_leaderboards.get(district)
+            if block_df is not None and len(block_df) > 0:
+                block_leaderboard_cache[district] = block_df
+                run_logger.info(f"Block leaderboard calculated for district", extra={AppInsightsLogHandler.DETAILS: {
+                    "context": "build_block_leaderboard",
+                    "district": district,
+                    "blocks_found": len(block_df)
+                }})
+            else:
+                block_leaderboard_cache[district] = None
+        
+        successful_districts = len([v for v in block_leaderboard_cache.values() if v is not None])
+        print(f"   ✅ Calculated {successful_districts}/{len(unique_districts)} district block leaderboards (optimized single-pass)")
+        run_logger.info("Block leaderboard cache ready", extra={AppInsightsLogHandler.DETAILS: {
+            "context": "block_leaderboard_cache_ready",
+            "successful_districts": successful_districts,
+            "total_districts": len(unique_districts),
+            "optimization": "single_pass"
+        }})
+    except Exception as e:
+        # Fallback: if optimized version fails, log error and continue without block leaderboards
+        run_logger.error(f"Error building block leaderboards (optimized)", extra={AppInsightsLogHandler.DETAILS: {
+            "context": "build_block_leaderboard_error",
+            "error": str(e)
+        }})
+        block_leaderboard_cache = {}  # Empty cache, will fall back to global leaderboard
+        print(f"   ⚠️  Error building block leaderboards: {str(e)}")
     
     results = []
     sent_count = 0

--- a/byoeb-v1/byoeb/byoeb/background_jobs/message_leaderboard/leaderboard.py
+++ b/byoeb-v1/byoeb/byoeb/background_jobs/message_leaderboard/leaderboard.py
@@ -1,20 +1,30 @@
 import asyncio
 import json
+import os
 from datetime import datetime, timedelta, timezone
 from zoneinfo import ZoneInfo
 from typing import Dict, Any, List, Optional
+from collections import Counter, defaultdict
 import pandas as pd
 import re
 
+from byoeb.application_logger.azure_app_insights import AppInsightsLogHandler
 from byoeb.chat_app.configuration.config import app_config
 from byoeb.chat_app.configuration.dependency_setup import get_leaderboard_service, user_db_service, message_db_service
 from byoeb.services.leaderboard.time_window_strategies import TimeWindowFactory
 
 IST = ZoneInfo("Asia/Kolkata")
 
-# TEST MODE: Set to True to use 3 parameters (district, count, users) for testing
-# Set to False to use full 9 parameters (3 districts * 3 fields each)
-TEST_MODE_3_PARAMS = False  # Changed to False to use real leaderboard data with 9 parameters
+# Azure App Insights Loggers
+run_logger = AppInsightsLogHandler.getLogger("leaderboard_run")
+send_logger = AppInsightsLogHandler.getLogger("leaderboard_send")
+
+# TEST MODE: Set to True to send only to your test phone number
+# Set to False to send to all users (production mode)
+TEST_MODE_SEND_TO_ME_ONLY = False  # Set to True for testing, False for production
+
+# Your test phone number (read from keys.env using PHONE_NUMBER_ID)
+TEST_PHONE_NUMBER = os.getenv("PHONE_NUMBER_ID") if TEST_MODE_SEND_TO_ME_ONLY else None
 
 def validate_and_format_phone_number(phone: str) -> Optional[str]:
     """
@@ -83,6 +93,145 @@ def print_delivery_troubleshooting(phone: str, message_id: str, status: str):
     print(f"   - Verify phone number format is correct")
     print(f"   - Check if template is fully approved (not just 'Active')")
     print(f"   - Try sending to a number that previously received messages")
+
+def get_user_district(user) -> Optional[str]:
+    """
+    Extract district from user object.
+    
+    Args:
+        user: User object (can be None, dict, or object with user_location attribute)
+        
+    Returns:
+        Optional[str]: District name or None if not found/unknown
+    """
+    if not user:
+        return None
+    loc = getattr(user, "user_location", None) or {}
+    if isinstance(loc, dict):
+        dist = loc.get("district") or loc.get("District")
+    else:
+        dist = getattr(loc, "district", None) or getattr(loc, "District", None)
+    if dist:
+        dist_str = str(dist).strip()
+        if dist_str.lower() not in ["unknown", "none", ""]:
+            return dist_str
+    return None
+
+def get_user_block(user) -> Optional[str]:
+    """
+    Extract block from user object.
+    
+    Args:
+        user: User object (can be None, dict, or object with user_location attribute)
+        
+    Returns:
+        Optional[str]: Block name or None if not found/unknown
+    """
+    if not user:
+        return None
+    loc = getattr(user, "user_location", None) or {}
+    if isinstance(loc, dict):
+        block = loc.get("block") or loc.get("Block")
+    else:
+        block = getattr(loc, "block", None) or getattr(loc, "Block", None)
+    if block:
+        block_str = str(block).strip()
+        if block_str.lower() not in ["unknown", "none", ""]:
+            return block_str
+    return None
+
+def has_location_info(user) -> bool:
+    """
+    Check if user has valid district and block information.
+    
+    Args:
+        user: User object
+        
+    Returns:
+        bool: True if user has both district and block, False otherwise
+    """
+    district = get_user_district(user)
+    block = get_user_block(user)
+    return district is not None and block is not None
+
+def get_type_indicator_translation(is_block_leaderboard: bool, user_language: str = "en") -> str:
+    """
+    Get translated type indicator ("Blocks" or "Districts") based on user language.
+    
+    Args:
+        is_block_leaderboard: If True, returns "Blocks" translation, otherwise "Districts" translation
+        user_language: User's language code (en, hi, mr, te)
+        
+    Returns:
+        Translated string for "Blocks" or "Districts"
+    """
+    # Translation dictionary for "Blocks" and "Districts"
+    translations = {
+        "en": {
+            "blocks": "Blocks",
+            "districts": "Districts"
+        },
+        "hi": {
+            "blocks": "ब्लॉक",
+            "districts": "जिले"
+        },
+        "mr": {
+            "blocks": "ब्लॉक",
+            "districts": "जिल्हे"
+        },
+        "te": {
+            "blocks": "బ్లాక్‌లు",
+            "districts": "జిల్లాలు"
+        }
+    }
+    
+    # Default to English if language not found
+    lang_dict = translations.get(user_language, translations["en"])
+    
+    if is_block_leaderboard:
+        return lang_dict["blocks"]
+    else:
+        return lang_dict["districts"]
+
+def get_prefix_translation(is_block_leaderboard: bool, user_language: str = "en") -> str:
+    """
+    Get translated prefix ("Block " or "District " with space) based on user language.
+    Used for prefixing names in parameters 1, 4, 7.
+    
+    Args:
+        is_block_leaderboard: If True, returns "Block " translation, otherwise "District " translation
+        user_language: User's language code (en, hi, mr, te)
+        
+    Returns:
+        Translated string for "Block " or "District " (with trailing space)
+    """
+    # Translation dictionary for "Block " and "District " (singular with space)
+    translations = {
+        "en": {
+            "block": "Block ",
+            "district": "District "
+        },
+        "hi": {
+            "block": "ब्लॉक ",
+            "district": "जिला "
+        },
+        "mr": {
+            "block": "ब्लॉक ",
+            "district": "जिल्हा "
+        },
+        "te": {
+            "block": "బ్లాక్ ",
+            "district": "జిల్లా "
+        }
+    }
+    
+    # Default to English if language not found
+    lang_dict = translations.get(user_language, translations["en"])
+    
+    if is_block_leaderboard:
+        return lang_dict["block"]
+    else:
+        return lang_dict["district"]
 
 async def fetch_phone_numbers_for_asha_and_test_users() -> List[str]:
     """
@@ -173,84 +322,185 @@ async def build_custom_leaderboard(days_back: int, message_categories: Optional[
     """
     return await build_district_leaderboard_with_strategy('custom', message_categories, processing_batch_size, days_back=days_back)
 
-async def format_leaderboard_as_template_parameters(top3_df: pd.DataFrame, test_mode_3_params: bool = True) -> List[str]:
+async def build_block_leaderboard_for_district(
+    district: str,
+    message_categories: Optional[List[str]] = None,
+    processing_batch_size: int = 1000
+) -> pd.DataFrame:
+    """
+    Builds a leaderboard of top 3 blocks within a specific district based on message activity from the previous week.
+    
+    Args:
+        district: District name to filter blocks by
+        message_categories: Optional list of message categories to filter by
+        processing_batch_size: Number of documents to process in each batch
+        
+    Returns:
+        pd.DataFrame: Sorted leaderboard with top 3 blocks in the district
+    """
+    week_strategy = TimeWindowFactory.create_strategy('week')
+    start_timestamp, end_timestamp = week_strategy.calculate_window()
+    
+    # Get repository instances from message_db_service
+    repository_factory = await message_db_service._get_repository_factory()
+    message_repository = await repository_factory.get_message_repository()
+    
+    # Define projection for required fields only
+    required_fields_only = {"_id": 0, "message_data.user.user_id": 1, "message_data.incoming_timestamp": 1}
+    
+    # Get messages using repository
+    message_iterator = await message_repository.find_messages_by_time_range(
+        start_timestamp=start_timestamp,
+        end_timestamp=end_timestamp,
+        message_categories=message_categories,
+        projection=required_fields_only
+    )
+    message_documents = [doc async for doc in message_iterator]
+    
+    # Sort messages by timestamp (descending)
+    message_documents.sort(key=lambda x: x.get("message_data", {}).get("incoming_timestamp", 0), reverse=True)
+    
+    if not user_db_service:
+        raise ValueError("user_db_service must be provided for leaderboard functionality")
+    
+    user_objects_cache = {}
+    block_message_counts = Counter()
+    block_unique_users = defaultdict(set)
+    block_first_message_timestamp = {}
+    block_last_message_timestamp = {}
+    
+    # Normalize district name for comparison (case-insensitive)
+    district_normalized = district.strip().lower()
+    
+    # Process messages in batches
+    for i in range(0, len(message_documents), processing_batch_size):
+        message_batch = message_documents[i:i + processing_batch_size]
+        
+        await user_db_service.hydrate_users(message_batch, user_objects_cache)
+        
+        for message_document in message_batch:
+            message_data = message_document.get("message_data", {})
+            user_id = message_data.get("user", {}).get("user_id")
+            message_timestamp = message_data.get("incoming_timestamp")
+            
+            if not isinstance(message_timestamp, int) or message_timestamp < start_timestamp or message_timestamp > end_timestamp:
+                continue
+            
+            user_object = user_objects_cache.get(user_id)
+            user_district = get_user_district(user_object)
+            user_block = get_user_block(user_object)
+            
+            # Only process if user is in the specified district and has block info
+            if not user_district or not user_block:
+                continue
+            
+            if user_district.strip().lower() != district_normalized:
+                continue
+            
+            block_message_counts[user_block] += 1
+            if user_id:
+                block_unique_users[user_block].add(user_id)
+            
+            block_first_message_timestamp[user_block] = min(block_first_message_timestamp.get(user_block, message_timestamp), message_timestamp)
+            block_last_message_timestamp[user_block] = max(block_last_message_timestamp.get(user_block, message_timestamp), message_timestamp)
+    
+    leaderboard_rows = [
+        {
+            "block": block_name,
+            "message_count": message_count,
+            "unique_users": len(block_unique_users[block_name]),
+            "first_seen": datetime.fromtimestamp(block_first_message_timestamp[block_name]).strftime("%d-%m-%Y %H:%M:%S"),
+            "last_seen": datetime.fromtimestamp(block_last_message_timestamp[block_name]).strftime("%d-%m-%Y %H:%M:%S")
+        }
+        for block_name, message_count in block_message_counts.items()
+    ]
+    
+    if not leaderboard_rows:
+        return pd.DataFrame(
+            columns=["block", "message_count", "unique_users", "first_seen", "last_seen"]
+        )
+    
+    # Sort by message_count and unique_users, then take top 3
+    df = pd.DataFrame(leaderboard_rows).sort_values(by=["message_count", "unique_users"], ascending=False, ignore_index=True)
+    return df.head(3)
+
+async def format_leaderboard_as_template_parameters(
+    top3_df: pd.DataFrame, 
+    is_block_leaderboard: bool = False,
+    user_language: str = "en"
+) -> List[str]:
     """
     Format leaderboard data as template parameters for WhatsApp template message.
     
     Args:
-        test_mode_3_params: If True, returns only 3 parameters for testing (district, count, users)
-                          If False, returns 9 parameters (3 districts * 3 fields each)
+        top3_df: DataFrame with leaderboard data (either districts or blocks)
+        is_block_leaderboard: If True, expects 'block' column, otherwise expects 'district' column
+        user_language: User's language code (en, hi, mr, te) for translating type indicator
     
     Returns:
-        List of parameters for the template
+        List of parameters for the template (includes translated type as last parameter: "Blocks" or "Districts")
     """
-    # TEST MODE: Return only 3 parameters (first district only)
-    if test_mode_3_params:
-        if len(top3_df) == 0:
-            return ["Test District", "28", "1"]  # Default test values
-        
-        # Get first district data
-        first_row = top3_df.iloc[0]
-        district = str(first_row['district']).strip() if pd.notna(first_row['district']) else "Test District"
-        message_count = str(int(first_row['message_count'])) if pd.notna(first_row['message_count']) else "28"
-        unique_users = str(int(first_row['unique_users'])) if pd.notna(first_row['unique_users']) else "1"
-        
-        parameters = [
-            district if district else "Test District",
-            message_count if message_count else "28",
-            unique_users if unique_users else "1"
-        ]
-        
-        # Validate: ensure exactly 3 parameters, all non-empty strings
-        assert len(parameters) == 3, f"Expected 3 parameters, got {len(parameters)}"
-        assert all(isinstance(p, str) and len(p) > 0 for p in parameters), \
-            f"All parameters must be non-empty strings. Got: {parameters}"
-        
-        return parameters
+    # Determine the type indicator (plural, translated based on user language)
+    type_indicator = get_type_indicator_translation(is_block_leaderboard, user_language)
     
-    # PRODUCTION MODE: Return 9 parameters (3 districts * 3 fields each)
+    # Get translated prefix for names
+    prefix = get_prefix_translation(is_block_leaderboard, user_language)
+    
+    # Always return 10 parameters (3 items * 3 fields + 1 type indicator)
     parameters = []
+    name_col = 'block' if is_block_leaderboard else 'district'
+    # prefix is already set above with translation
     
-    # Add parameters for existing districts
+    # Add parameters for existing items
     for idx, row in top3_df.iterrows():
-        district = str(row['district']).strip() if pd.notna(row['district']) else "N/A"
+        raw_name = str(row[name_col]).strip() if pd.notna(row[name_col]) else "N/A"
+        
+        # Add translated prefix: "Block " for blocks, "District " for districts
+        if raw_name and raw_name != "N/A":
+            name = prefix + raw_name
+        else:
+            name = "N/A"
+        
         message_count = str(int(row['message_count'])) if pd.notna(row['message_count']) else "0"
         unique_users = str(int(row['unique_users'])) if pd.notna(row['unique_users']) else "0"
         
         # Ensure no empty strings or None values
-        parameters.append(district if district else "N/A")
+        parameters.append(name if name else "N/A")
         parameters.append(message_count if message_count else "0")
         parameters.append(unique_users if unique_users else "0")
     
-    # If less than 3 districts, pad with placeholder values
+    # If less than 3 items, pad with placeholder values
     # WhatsApp requires all parameters to be non-empty strings
-    # Use "N/A" for missing district names and "0" for missing counts
+    # Use "N/A" for missing names and "0" for missing counts
     while len(parameters) < 9:
-        if len(parameters) % 3 == 0:  # District name position (0, 3, 6)
+        if len(parameters) % 3 == 0:  # Name position (0, 3, 6)
             parameters.append("N/A")
         else:  # Count or users position (1, 2, 4, 5, 7, 8)
             parameters.append("0")
     
-    # Validate: ensure exactly 9 parameters, all non-empty strings
-    assert len(parameters) == 9, f"Expected 9 parameters, got {len(parameters)}"
+    # Add 10th parameter: type indicator ("Blocks" or "Districts" - translated based on user language)
+    parameters.append(type_indicator)
+    
+    # Validate: ensure exactly 10 parameters, all non-empty strings
+    assert len(parameters) == 10, f"Expected 10 parameters, got {len(parameters)}"
     assert all(isinstance(p, str) and len(p) > 0 for p in parameters), \
         f"All parameters must be non-empty strings. Got: {parameters}"
     
-    return parameters[:9]  # Ensure exactly 9 parameters (3 districts * 3 fields each)
+    return parameters[:10]  # Ensure exactly 10 parameters (3 items * 3 fields + 1 type)
 
 async def send_leaderboard_template_messages(
     phone_numbers: List[str],
     top3_df: pd.DataFrame,
     user_db_service,
-    message_db_service,
-    test_mode_3_params: bool = True
+    message_db_service
 ):
     """
     Send leaderboard messages as WhatsApp template messages to all users.
     
-    Args:
-        test_mode_3_params: If True, uses 3 parameters (district, count, users) for testing
-                           If False, uses 9 parameters (3 districts * 3 fields each)
+    NOTE: This function ONLY READS from the database (no modifications).
+    It uses: find_messages_by_time_range, get_users, hydrate_users - all read-only operations.
+    
+    Sends 10 parameters: 3 items × (name, message_count, unique_users) + type indicator
     """
     from byoeb.chat_app.configuration.dependency_setup import channel_client_factory
     from byoeb.services.channel.whatsapp import WhatsAppService
@@ -266,9 +516,54 @@ async def send_leaderboard_template_messages(
     users = await user_db_service.get_users(user_ids)
     user_map = {user.phone_number_id: user for user in users if user}
     
-    # Format template parameters
-    # Format template parameters (using test mode if enabled)
-    template_parameters = await format_leaderboard_as_template_parameters(top3_df, test_mode_3_params=test_mode_3_params)
+    # Pre-calculate block leaderboards for all unique districts to avoid recalculating
+    # This is much more efficient than calculating for each user individually
+    unique_districts = set()
+    for user in users:
+        if user and has_location_info(user):
+            district = get_user_district(user)
+            if district:
+                unique_districts.add(district.strip().lower())
+    
+    print(f"\n📊 Pre-calculating block leaderboards for {len(unique_districts)} unique districts...")
+    run_logger.info("Pre-calculating block leaderboards", extra={AppInsightsLogHandler.DETAILS: {
+        "context": "pre_calculate_block_leaderboards",
+        "unique_districts_count": len(unique_districts),
+        "districts": list(unique_districts)
+    }})
+    
+    block_leaderboard_cache = {}
+    for district in unique_districts:
+        try:
+            print(f"   Calculating block leaderboard for district: {district}")
+            block_df = await build_block_leaderboard_for_district(
+                district=district,
+                message_categories=None,
+                processing_batch_size=1000
+            )
+            block_leaderboard_cache[district] = block_df
+            print(f"   ✅ Found {len(block_df)} blocks for {district}")
+            run_logger.info(f"Block leaderboard calculated for district", extra={AppInsightsLogHandler.DETAILS: {
+                "context": "build_block_leaderboard",
+                "district": district,
+                "blocks_found": len(block_df)
+            }})
+        except Exception as e:
+            print(f"   ⚠️  Error building block leaderboard for {district}: {e}")
+            block_leaderboard_cache[district] = None  # Cache None to avoid retrying
+            run_logger.error(f"Error building block leaderboard for district", extra={AppInsightsLogHandler.DETAILS: {
+                "context": "build_block_leaderboard_error",
+                "district": district,
+                "error": str(e)
+            }})
+    
+    successful_districts = len([v for v in block_leaderboard_cache.values() if v is not None])
+    print(f"✅ Block leaderboard cache ready with {successful_districts} districts\n")
+    run_logger.info("Block leaderboard cache ready", extra={AppInsightsLogHandler.DETAILS: {
+        "context": "block_leaderboard_cache_ready",
+        "successful_districts": successful_districts,
+        "total_districts": len(unique_districts)
+    }})
     
     results = []
     for phone in phone_numbers:
@@ -277,6 +572,11 @@ async def send_leaderboard_template_messages(
             formatted_phone = validate_and_format_phone_number(phone)
             if not formatted_phone:
                 print(f"❌ Invalid phone number format: {phone}")
+                send_logger.warning("Invalid phone number format", extra={AppInsightsLogHandler.DETAILS: {
+                    "context": "validate_phone_number",
+                    "phone": phone,
+                    "user_id": user.user_id if user else None
+                }})
                 results.append({
                     "phone": phone,
                     "status": "error",
@@ -292,11 +592,77 @@ async def send_leaderboard_template_messages(
             user = user_map.get(phone)
             user_language = user.user_language if user and user.user_language else 'en'
             
-            # Validate template parameters before sending
-            expected_params = 3 if test_mode_3_params else 9
-            if not template_parameters or len(template_parameters) != expected_params:
+            # Determine which leaderboard to use for this user
+            # If user has district and block info, show top 3 blocks in their district
+            # Otherwise, show global top 3 districts
+            user_has_location = has_location_info(user)
+            is_block_leaderboard = False
+            user_leaderboard_df = top3_df  # Default to global districts
+            
+            if user_has_location:
+                user_district = get_user_district(user)
+                if user_district:
+                    district_key = user_district.strip().lower()
+                    # Use cached block leaderboard if available
+                    if district_key in block_leaderboard_cache:
+                        cached_block_df = block_leaderboard_cache[district_key]
+                        if cached_block_df is not None and len(cached_block_df) > 0:
+                            user_leaderboard_df = cached_block_df
+                            is_block_leaderboard = True
+                            print(f"📍 User {phone} → Using cached block leaderboard for district {user_district} ({len(cached_block_df)} blocks)")
+                            send_logger.debug("Using block leaderboard for user", extra={AppInsightsLogHandler.DETAILS: {
+                                "context": "user_block_leaderboard",
+                                "phone": phone,
+                                "user_id": user.user_id if user else None,
+                                "district": user_district,
+                                "blocks_count": len(cached_block_df)
+                            }})
+                        else:
+                            print(f"📍 User {phone} → No blocks found for district {user_district}, using global leaderboard")
+                            send_logger.debug("No blocks found, using global leaderboard", extra={AppInsightsLogHandler.DETAILS: {
+                                "context": "user_fallback_global",
+                                "phone": phone,
+                                "user_id": user.user_id if user else None,
+                                "district": user_district,
+                                "reason": "no_blocks_found"
+                            }})
+                    else:
+                        print(f"📍 User {phone} → District {user_district} not in cache, using global leaderboard")
+                        send_logger.debug("District not in cache, using global leaderboard", extra={AppInsightsLogHandler.DETAILS: {
+                            "context": "user_fallback_global",
+                            "phone": phone,
+                            "user_id": user.user_id if user else None,
+                            "district": user_district,
+                            "reason": "not_in_cache"
+                        }})
+                else:
+                    print(f"📍 User {phone} → Has location info but no district, using global leaderboard")
+                    send_logger.debug("User has location but no district", extra={AppInsightsLogHandler.DETAILS: {
+                        "context": "user_fallback_global",
+                        "phone": phone,
+                        "user_id": user.user_id if user else None,
+                        "reason": "no_district"
+                    }})
+            else:
+                print(f"📍 User {phone} → No location info, using global district leaderboard")
+                send_logger.debug("User has no location info", extra={AppInsightsLogHandler.DETAILS: {
+                    "context": "user_fallback_global",
+                    "phone": phone,
+                    "user_id": user.user_id if user else None,
+                    "reason": "no_location_info"
+                }})
+            
+            # Format template parameters based on user's leaderboard
+            template_parameters = await format_leaderboard_as_template_parameters(
+                user_leaderboard_df, 
+                is_block_leaderboard=is_block_leaderboard,
+                user_language=user_language
+            )
+            
+            # Validate template parameters before sending (always expect 10 parameters)
+            if not template_parameters or len(template_parameters) != 10:
                 print(f"❌ ERROR: Invalid template parameters for {phone}")
-                print(f"   Expected {expected_params} parameters, got: {len(template_parameters) if template_parameters else 0}")
+                print(f"   Expected 10 parameters, got: {len(template_parameters) if template_parameters else 0}")
                 print(f"   Parameters: {template_parameters}")
                 continue
             
@@ -317,18 +683,21 @@ async def send_leaderboard_template_messages(
             template_parameters = validated_parameters
             
             # Build a text representation of the leaderboard (for logging/fallback)
-            if test_mode_3_params:
-                # Test mode: Only 3 parameters (district, count, users)
-                leaderboard_text = f"Top District: {template_parameters[0]}: {template_parameters[1]} msgs, {template_parameters[2]} users"
+            # Last parameter is the translated type indicator ("Blocks" or "Districts")
+            type_indicator = template_parameters[-1] if len(template_parameters) > 0 else get_type_indicator_translation(is_block_leaderboard, user_language)
+            
+            # Build leaderboard text: 10 parameters (9 data + 1 type)
+            if type_indicator in ["Block", "ब्लॉक", "బ్లాక్"]:  # Block indicators
+                leaderboard_text = "📊 Top 3 Blocks in Your District with Highest Interactions:\n\n"
             else:
-                # Production mode: 9 parameters (3 districts * 3 fields)
                 leaderboard_text = "📊 Top 3 Districts with Highest Interactions:\n\n"
-                for i in range(0, 9, 3):
-                    district = template_parameters[i]
-                    count = template_parameters[i+1]
-                    users = template_parameters[i+2]
-                    if district != "N/A":
-                        leaderboard_text += f"{i//3 + 1}) {district}: {count} messages from {users} users\n"
+            
+            for i in range(0, 9, 3):
+                item = template_parameters[i]
+                count = template_parameters[i+1]
+                users = template_parameters[i+2]
+                if item != "N/A":
+                    leaderboard_text += f"{i//3 + 1}) {item}: {count} messages from {users} users\n"
             
             # Create ByoebMessageContext with template information
             # Following the consensus pattern: create with REGULAR_TEXT and text fields,
@@ -396,17 +765,7 @@ async def send_leaderboard_template_messages(
                 print(f"   Template: {constants.TEMPLATE_NAME}={byoeb_message.message_context.additional_info[constants.TEMPLATE_NAME]}")
                 print(f"   Parameters ({len(template_parameters)}): {template_parameters}")
                 print(f"   Parameter validation: All parameters are non-empty strings: {all(isinstance(p, str) and len(p) > 0 for p in template_parameters)}")
-                
-                if test_mode_3_params:
-                    print(f"\n🧪 TEST MODE: Using 3 parameters for testing")
-                    print(f"   Template should have exactly 3 variables: {{1}}, {{2}}, {{3}}")
-                else:
-                    # ⚠️ IMPORTANT: Check template character limit
-                    print(f"\n⚠️  TEMPLATE CHARACTER LIMIT WARNING:")
-                    print(f"   Your template body is 172 characters, but WhatsApp limit is 106 characters.")
-                    print(f"   This may prevent message delivery even if API accepts it.")
-                    print(f"   Please shorten the template body in WhatsApp Business Manager.")
-                    print(f"   Suggested: Remove emoji or shorten text to fit within 106 characters.")
+                print(f"   Using 10 parameters: 3 items × (name, count, users) + type indicator")
                 
                 # Log the exact payload being sent (for debugging)
                 print(f"\n   📋 WhatsApp API Payload:")
@@ -438,17 +797,56 @@ async def send_leaderboard_template_messages(
                             print(f"✅ Template message accepted by WhatsApp API for {phone}")
                             print(f"   ⏳ Delivery may take 1-5 minutes")
                             print(f"   📱 Please check your WhatsApp after a few minutes")
+                            send_logger.info("Leaderboard message accepted by WhatsApp API", extra={AppInsightsLogHandler.DETAILS: {
+                                "context": "message_accepted",
+                                "phone": phone,
+                                "user_id": user.user_id if user else None,
+                                "message_id": message_id,
+                                "language": user_language,
+                                "is_block_leaderboard": is_block_leaderboard,
+                                "whatsapp_status": status
+                            }})
                             # Print troubleshooting info
                             if message_id:
                                 print_delivery_troubleshooting(phone, message_id, status)
                         elif msg_status == 'sent':
                             print(f"✅ Template message sent to {phone}")
+                            send_logger.info("Leaderboard message sent", extra={AppInsightsLogHandler.DETAILS: {
+                                "context": "message_sent",
+                                "phone": phone,
+                                "user_id": user.user_id if user else None,
+                                "message_id": message_id,
+                                "language": user_language
+                            }})
                         elif msg_status == 'delivered':
                             print(f"✅✅ Message delivered to {phone}!")
+                            send_logger.info("Leaderboard message delivered", extra={AppInsightsLogHandler.DETAILS: {
+                                "context": "message_delivered",
+                                "phone": phone,
+                                "user_id": user.user_id if user else None,
+                                "message_id": message_id,
+                                "language": user_language
+                            }})
                         elif msg_status == 'read':
                             print(f"✅✅✅ Message read by {phone}!")
+                            send_logger.info("Leaderboard message read", extra={AppInsightsLogHandler.DETAILS: {
+                                "context": "message_read",
+                                "phone": phone,
+                                "user_id": user.user_id if user else None,
+                                "message_id": message_id,
+                                "language": user_language
+                            }})
                         else:
                             print(f"⚠️  Message status: {msg_status} (may indicate delivery issue)")
+                            send_logger.warning("Leaderboard message status issue", extra={AppInsightsLogHandler.DETAILS: {
+                                "context": "message_status_warning",
+                                "phone": phone,
+                                "user_id": user.user_id if user else None,
+                                "message_id": message_id,
+                                "message_status": msg_status,
+                                "whatsapp_status": status,
+                                "error": error
+                            }})
                             if message_id:
                                 print_delivery_troubleshooting(phone, message_id, status)
                     
@@ -463,6 +861,12 @@ async def send_leaderboard_template_messages(
                     })
                 else:
                     print(f"❌ No response received from WhatsApp API for {phone}")
+                    send_logger.error("No response from WhatsApp API", extra={AppInsightsLogHandler.DETAILS: {
+                        "context": "no_whatsapp_response",
+                        "phone": phone,
+                        "user_id": user.user_id if user else None,
+                        "language": user_language
+                    }})
                     results.append({
                         "phone": phone,
                         "status": "error",
@@ -470,6 +874,12 @@ async def send_leaderboard_template_messages(
                     })
             else:
                 print(f"❌ Failed to prepare template request for {phone}")
+                send_logger.error("Failed to prepare template request", extra={AppInsightsLogHandler.DETAILS: {
+                    "context": "prepare_request_failed",
+                    "phone": phone,
+                    "user_id": user.user_id if user else None,
+                    "language": user_language
+                }})
                 results.append({
                     "phone": phone,
                     "status": "error",
@@ -477,6 +887,13 @@ async def send_leaderboard_template_messages(
                 })
         except Exception as e:
             print(f"❌ Error sending to {phone}: {str(e)}")
+            send_logger.error("Error sending leaderboard message", extra={AppInsightsLogHandler.DETAILS: {
+                "context": "send_error",
+                "phone": phone,
+                "user_id": user.user_id if user else None,
+                "error": str(e),
+                "language": user_language if 'user_language' in locals() else None
+            }})
             results.append({
                 "phone": phone,
                 "status": "error",
@@ -486,33 +903,90 @@ async def send_leaderboard_template_messages(
     return results
 
 async def main():
+    run_logger.info("Starting leaderboard job", extra={AppInsightsLogHandler.DETAILS: {
+        "context": "leaderboard_job_start",
+        "test_mode": TEST_MODE_SEND_TO_ME_ONLY,
+        "test_phone": TEST_PHONE_NUMBER if TEST_MODE_SEND_TO_ME_ONLY else None
+    }})
+    
+    # Build global district leaderboard (used as fallback for users without location info)
     leaderboard_df = await build_district_leaderboard_last_week_ist()
     top3_df = leaderboard_df.head(3)
-    print("\nTop 3 Districts:\n", top3_df.to_string(index=False))
+    print("\nTop 3 Districts (Global - used for users without location info):\n", top3_df.to_string(index=False))
+    
+    run_logger.info("Global district leaderboard built", extra={AppInsightsLogHandler.DETAILS: {
+        "context": "build_global_leaderboard",
+        "total_districts": len(leaderboard_df),
+        "top3_districts": top3_df.to_dict('records') if len(top3_df) > 0 else []
+    }})
 
-    phone_numbers = await fetch_phone_numbers_for_asha_and_test_users()
-    print(f"Total recipients found: {len(phone_numbers)}")
-    
-    # Display what will be sent
-    template_params = await format_leaderboard_as_template_parameters(top3_df, test_mode_3_params=TEST_MODE_3_PARAMS)
-    print(f"\nTemplate Parameters: {template_params}")
+    # Display what will be sent (sample for global leaderboard)
+    # Note: In actual sending, each user gets their own language-specific translation
+    template_params = await format_leaderboard_as_template_parameters(top3_df, user_language="en")
+    print(f"\nSample Template Parameters (Global Districts, English): {template_params}")
+    print(f"   Note: 10th parameter will be translated based on each user's language")
     print(f"Template Name: leaderboardv2")
-    if TEST_MODE_3_PARAMS:
-        print(f"🧪 TEST MODE: Using 3 parameters (district, count, users)")
-    else:
-        print(f"📊 PRODUCTION MODE: Using 9 parameters (3 districts)")
+    print(f"\n📌 PERSONALIZATION LOGIC:")
+    print(f"   - Users WITH district & block info → Top 3 blocks in their district")
+    print(f"   - Users WITHOUT location info → Top 3 districts (global)")
+    print(f"📊 Using 10 parameters: 3 items × (name, count, users) + type indicator")
     
-    # PRODUCTION MODE: Send to all users (actual sending)
-    print(f"\n🚀 PRODUCTION MODE: Sending template messages to {len(phone_numbers)} users")
-    results = await send_leaderboard_template_messages(
-        phone_numbers, 
-        top3_df, 
-        user_db_service, 
-        message_db_service,
-        test_mode_3_params=TEST_MODE_3_PARAMS
-    )
-    success_count = sum(1 for r in results if r.get("status") == "success")
-    print(f"\n✅ Successfully sent {success_count} out of {len(results)} messages")
+    # TEST MODE: Send only to your test phone number
+    if TEST_MODE_SEND_TO_ME_ONLY:
+        if not TEST_PHONE_NUMBER:
+            print(f"\n❌ ERROR: TEST_MODE_SEND_TO_ME_ONLY is True but PHONE_NUMBER_ID is not set in keys.env")
+            print(f"   Please add PHONE_NUMBER_ID=your_phone_number to your keys.env file")
+            return
+        
+        print(f"\n🧪 TEST MODE: Sending template message only to {TEST_PHONE_NUMBER}")
+        print(f"   ✅ SAFETY CHECK: TEST_MODE_SEND_TO_ME_ONLY = True")
+        print(f"   ✅ Only 1 recipient will receive the message")
+        test_phone_numbers = [TEST_PHONE_NUMBER]
+        results = await send_leaderboard_template_messages(
+            test_phone_numbers, 
+            top3_df, 
+            user_db_service, 
+            message_db_service
+        )
+        success_count = sum(1 for r in results if r.get("status") == "success")
+        failure_count = len(results) - success_count
+        print(f"\n✅ Successfully sent {success_count} out of {len(results)} messages")
+        print(f"\n⚠️  TEST MODE ACTIVE: Only sent to test phone number")
+        print(f"   To enable production mode, set TEST_MODE_SEND_TO_ME_ONLY = False")
+        
+        run_logger.info("Leaderboard job completed (test mode)", extra={AppInsightsLogHandler.DETAILS: {
+            "context": "leaderboard_job_complete",
+            "mode": "test",
+            "total_recipients": len(results),
+            "success_count": success_count,
+            "failure_count": failure_count,
+            "test_phone": TEST_PHONE_NUMBER
+        }})
+    else:
+        # PRODUCTION MODE: Send to all users (actual sending)
+        print(f"\n⚠️  WARNING: PRODUCTION MODE ACTIVE!")
+        print(f"   TEST_MODE_SEND_TO_ME_ONLY = False")
+        print(f"   Messages will be sent to ALL users")
+        phone_numbers = await fetch_phone_numbers_for_asha_and_test_users()
+        print(f"Total recipients found: {len(phone_numbers)}")
+        print(f"\n🚀 PRODUCTION MODE: Sending template messages to {len(phone_numbers)} users")
+        results = await send_leaderboard_template_messages(
+            phone_numbers, 
+            top3_df, 
+            user_db_service, 
+            message_db_service
+        )
+        success_count = sum(1 for r in results if r.get("status") == "success")
+        failure_count = len(results) - success_count
+        print(f"\n✅ Successfully sent {success_count} out of {len(results)} messages")
+        
+        run_logger.info("Leaderboard job completed (production mode)", extra={AppInsightsLogHandler.DETAILS: {
+            "context": "leaderboard_job_complete",
+            "mode": "production",
+            "total_recipients": len(results),
+            "success_count": success_count,
+            "failure_count": failure_count
+        }})
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/byoeb-v1/byoeb/byoeb/background_jobs/message_leaderboard/leaderboard.py
+++ b/byoeb-v1/byoeb/byoeb/background_jobs/message_leaderboard/leaderboard.py
@@ -114,7 +114,7 @@ def get_user_district(user) -> Optional[str]:
     if dist:
         dist_str = str(dist).strip()
         if dist_str.lower() not in ["unknown", "none", ""]:
-            return dist_str
+            return dist_str.title()
     return None
 
 def get_user_block(user) -> Optional[str]:
@@ -137,7 +137,7 @@ def get_user_block(user) -> Optional[str]:
     if block:
         block_str = str(block).strip()
         if block_str.lower() not in ["unknown", "none", ""]:
-            return block_str
+            return block_str.title()
     return None
 
 def has_location_info(user) -> bool:
@@ -154,84 +154,52 @@ def has_location_info(user) -> bool:
     block = get_user_block(user)
     return district is not None and block is not None
 
-def get_type_indicator_translation(is_block_leaderboard: bool, user_language: str = "en") -> str:
-    """
-    Get translated type indicator ("Blocks" or "Districts") based on user language.
-    
-    Args:
-        is_block_leaderboard: If True, returns "Blocks" translation, otherwise "Districts" translation
-        user_language: User's language code (en, hi, mr, te)
-        
-    Returns:
-        Translated string for "Blocks" or "Districts"
-    """
-    # Translation dictionary for "Blocks" and "Districts"
-    translations = {
-        "en": {
-            "blocks": "Blocks",
-            "districts": "Districts"
-        },
-        "hi": {
-            "blocks": "ब्लॉक",
-            "districts": "जिले"
-        },
-        "mr": {
-            "blocks": "ब्लॉक",
-            "districts": "जिल्हे"
-        },
-        "te": {
-            "blocks": "బ్లాక్‌లు",
-            "districts": "జిల్లాలు"
-        }
+# Unified translation dictionary for leaderboard text
+LEADERBOARD_TRANSLATIONS = {
+    "en": {
+        "block_singular": "Block ",      # With trailing space for prefixing
+        "district_singular": "District ",
+        "blocks_plural": "Blocks",
+        "districts_plural": "Districts"
+    },
+    "hi": {
+        "block_singular": "ब्लॉक ",
+        "district_singular": "जिला ",
+        "blocks_plural": "ब्लॉक",
+        "districts_plural": "जिले"
+    },
+    "mr": {
+        "block_singular": "ब्लॉक ",
+        "district_singular": "जिल्हा ",
+        "blocks_plural": "ब्लॉक",
+        "districts_plural": "जिल्हे"
+    },
+    "te": {
+        "block_singular": "బ్లాక్ ",
+        "district_singular": "జిల్లా ",
+        "blocks_plural": "బ్లాక్‌లు",
+        "districts_plural": "జిల్లాలు"
     }
-    
-    # Default to English if language not found
-    lang_dict = translations.get(user_language, translations["en"])
-    
-    if is_block_leaderboard:
-        return lang_dict["blocks"]
-    else:
-        return lang_dict["districts"]
+}
 
-def get_prefix_translation(is_block_leaderboard: bool, user_language: str = "en") -> str:
+def get_leaderboard_translation(is_block_leaderboard: bool, user_language: str = "en", plural: bool = False) -> str:
     """
-    Get translated prefix ("Block " or "District " with space) based on user language.
-    Used for prefixing names in parameters 1, 4, 7.
+    Get translated text for block/district leaderboard labels.
     
     Args:
-        is_block_leaderboard: If True, returns "Block " translation, otherwise "District " translation
+        is_block_leaderboard: If True, returns block translation, otherwise district translation
         user_language: User's language code (en, hi, mr, te)
+        plural: If True, returns plural form (Blocks/Districts), otherwise singular with space (Block /District )
         
     Returns:
-        Translated string for "Block " or "District " (with trailing space)
+        Translated string
     """
-    # Translation dictionary for "Block " and "District " (singular with space)
-    translations = {
-        "en": {
-            "block": "Block ",
-            "district": "District "
-        },
-        "hi": {
-            "block": "ब्लॉक ",
-            "district": "जिला "
-        },
-        "mr": {
-            "block": "ब्लॉक ",
-            "district": "जिल्हा "
-        },
-        "te": {
-            "block": "బ్లాక్ ",
-            "district": "జిల్లా "
-        }
-    }
+    lang_dict = LEADERBOARD_TRANSLATIONS.get(user_language, LEADERBOARD_TRANSLATIONS["en"])
     
-    # Default to English if language not found
-    lang_dict = translations.get(user_language, translations["en"])
-    
-    if is_block_leaderboard:
-        return lang_dict["block"]
+    if plural:
+        return lang_dict["blocks_plural"] if is_block_leaderboard else lang_dict["districts_plural"]
     else:
-        return lang_dict["district"]
+        return lang_dict["block_singular"] if is_block_leaderboard else lang_dict["district_singular"]
 
 async def fetch_phone_numbers_for_asha_and_test_users() -> List[str]:
     """
@@ -440,11 +408,9 @@ async def format_leaderboard_as_template_parameters(
     Returns:
         List of parameters for the template (includes translated type as last parameter: "Blocks" or "Districts")
     """
-    # Determine the type indicator (plural, translated based on user language)
-    type_indicator = get_type_indicator_translation(is_block_leaderboard, user_language)
-    
-    # Get translated prefix for names
-    prefix = get_prefix_translation(is_block_leaderboard, user_language)
+    # Get translated type indicator (plural) and prefix (singular with space)
+    type_indicator = get_leaderboard_translation(is_block_leaderboard, user_language, plural=True)
+    prefix = get_leaderboard_translation(is_block_leaderboard, user_language, plural=False)
     
     # Always return 10 parameters (3 items * 3 fields + 1 type indicator)
     parameters = []
@@ -684,7 +650,7 @@ async def send_leaderboard_template_messages(
             
             # Build a text representation of the leaderboard (for logging/fallback)
             # Last parameter is the translated type indicator ("Blocks" or "Districts")
-            type_indicator = template_parameters[-1] if len(template_parameters) > 0 else get_type_indicator_translation(is_block_leaderboard, user_language)
+            type_indicator = template_parameters[-1] if len(template_parameters) > 0 else get_leaderboard_translation(is_block_leaderboard, user_language, plural=True)
             
             # Build leaderboard text: 10 parameters (9 data + 1 type)
             if type_indicator in ["Block", "ब्लॉक", "బ్లాక్"]:  # Block indicators
@@ -931,7 +897,7 @@ async def main():
     print(f"   - Users WITHOUT location info → Top 3 districts (global)")
     print(f"📊 Using 10 parameters: 3 items × (name, count, users) + type indicator")
     
-    # TEST MODE: Send only to your test phone number
+    # Collect phone numbers based on mode
     if TEST_MODE_SEND_TO_ME_ONLY:
         if not TEST_PHONE_NUMBER:
             print(f"\n❌ ERROR: TEST_MODE_SEND_TO_ME_ONLY is True but PHONE_NUMBER_ID is not set in keys.env")
@@ -941,52 +907,46 @@ async def main():
         print(f"\n🧪 TEST MODE: Sending template message only to {TEST_PHONE_NUMBER}")
         print(f"   ✅ SAFETY CHECK: TEST_MODE_SEND_TO_ME_ONLY = True")
         print(f"   ✅ Only 1 recipient will receive the message")
-        test_phone_numbers = [TEST_PHONE_NUMBER]
-        results = await send_leaderboard_template_messages(
-            test_phone_numbers, 
-            top3_df, 
-            user_db_service, 
-            message_db_service
-        )
-        success_count = sum(1 for r in results if r.get("status") == "success")
-        failure_count = len(results) - success_count
-        print(f"\n✅ Successfully sent {success_count} out of {len(results)} messages")
-        print(f"\n⚠️  TEST MODE ACTIVE: Only sent to test phone number")
-        print(f"   To enable production mode, set TEST_MODE_SEND_TO_ME_ONLY = False")
-        
-        run_logger.info("Leaderboard job completed (test mode)", extra={AppInsightsLogHandler.DETAILS: {
-            "context": "leaderboard_job_complete",
-            "mode": "test",
-            "total_recipients": len(results),
-            "success_count": success_count,
-            "failure_count": failure_count,
-            "test_phone": TEST_PHONE_NUMBER
-        }})
+        phone_numbers = [TEST_PHONE_NUMBER]
+        mode = "test"
     else:
-        # PRODUCTION MODE: Send to all users (actual sending)
         print(f"\n⚠️  WARNING: PRODUCTION MODE ACTIVE!")
         print(f"   TEST_MODE_SEND_TO_ME_ONLY = False")
         print(f"   Messages will be sent to ALL users")
         phone_numbers = await fetch_phone_numbers_for_asha_and_test_users()
         print(f"Total recipients found: {len(phone_numbers)}")
-        print(f"\n🚀 PRODUCTION MODE: Sending template messages to {len(phone_numbers)} users")
-        results = await send_leaderboard_template_messages(
-            phone_numbers, 
-            top3_df, 
-            user_db_service, 
-            message_db_service
-        )
-        success_count = sum(1 for r in results if r.get("status") == "success")
-        failure_count = len(results) - success_count
-        print(f"\n✅ Successfully sent {success_count} out of {len(results)} messages")
-        
-        run_logger.info("Leaderboard job completed (production mode)", extra={AppInsightsLogHandler.DETAILS: {
-            "context": "leaderboard_job_complete",
-            "mode": "production",
-            "total_recipients": len(results),
-            "success_count": success_count,
-            "failure_count": failure_count
-        }})
+        mode = "production"
+    
+    # Send messages to collected phone numbers
+    print(f"\n🚀 Sending template messages to {len(phone_numbers)} users")
+    results = await send_leaderboard_template_messages(
+        phone_numbers, 
+        top3_df, 
+        user_db_service, 
+        message_db_service
+    )
+    
+    # Calculate and report results
+    success_count = sum(1 for r in results if r.get("status") == "success")
+    failure_count = len(results) - success_count
+    print(f"\n✅ Successfully sent {success_count} out of {len(results)} messages")
+    
+    if TEST_MODE_SEND_TO_ME_ONLY:
+        print(f"\n⚠️  TEST MODE ACTIVE: Only sent to test phone number")
+        print(f"   To enable production mode, set TEST_MODE_SEND_TO_ME_ONLY = False")
+    
+    # Log completion
+    log_details = {
+        "context": "leaderboard_job_complete",
+        "mode": mode,
+        "total_recipients": len(results),
+        "success_count": success_count,
+        "failure_count": failure_count
+    }
+    if TEST_MODE_SEND_TO_ME_ONLY:
+        log_details["test_phone"] = TEST_PHONE_NUMBER
+    
+    run_logger.info(f"Leaderboard job completed ({mode} mode)", extra={AppInsightsLogHandler.DETAILS: log_details})
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/byoeb-v1/byoeb/byoeb/background_jobs/message_leaderboard/leaderboard.py
+++ b/byoeb-v1/byoeb/byoeb/background_jobs/message_leaderboard/leaderboard.py
@@ -12,6 +12,7 @@ from byoeb.application_logger.azure_app_insights import AppInsightsLogHandler
 from byoeb.chat_app.configuration.config import app_config
 from byoeb.chat_app.configuration.dependency_setup import get_leaderboard_service, user_db_service, message_db_service
 from byoeb.services.leaderboard.time_window_strategies import TimeWindowFactory
+from byoeb.services.user.utils import get_user_district, get_user_block, has_location_info
 
 IST = ZoneInfo("Asia/Kolkata")
 
@@ -58,67 +59,6 @@ def validate_and_format_phone_number(phone: str) -> Optional[str]:
         return digits_only
     
     return None
-
-
-def get_user_district(user) -> Optional[str]:
-    """
-    Extract district from user object.
-    
-    Args:
-        user: User object (can be None, dict, or object with user_location attribute)
-        
-    Returns:
-        Optional[str]: District name or None if not found/unknown
-    """
-    if not user:
-        return None
-    loc = getattr(user, "user_location", None) or {}
-    if isinstance(loc, dict):
-        dist = loc.get("district") or loc.get("District")
-    else:
-        dist = getattr(loc, "district", None) or getattr(loc, "District", None)
-    if dist:
-        dist_str = str(dist).strip()
-        if dist_str.lower() not in ["unknown", "none", ""]:
-            return dist_str.title()
-    return None
-
-def get_user_block(user) -> Optional[str]:
-    """
-    Extract block from user object.
-    
-    Args:
-        user: User object (can be None, dict, or object with user_location attribute)
-        
-    Returns:
-        Optional[str]: Block name or None if not found/unknown
-    """
-    if not user:
-        return None
-    loc = getattr(user, "user_location", None) or {}
-    if isinstance(loc, dict):
-        block = loc.get("block") or loc.get("Block")
-    else:
-        block = getattr(loc, "block", None) or getattr(loc, "Block", None)
-    if block:
-        block_str = str(block).strip()
-        if block_str.lower() not in ["unknown", "none", ""]:
-            return block_str.title()
-    return None
-
-def has_location_info(user) -> bool:
-    """
-    Check if user has valid district and block information.
-    
-    Args:
-        user: User object
-        
-    Returns:
-        bool: True if user has both district and block, False otherwise
-    """
-    district = get_user_district(user)
-    block = get_user_block(user)
-    return district is not None and block is not None
 
 # Unified translation dictionary for leaderboard text
 LEADERBOARD_TRANSLATIONS = {

--- a/byoeb-v1/byoeb/byoeb/background_jobs/message_leaderboard/leaderboard.py
+++ b/byoeb-v1/byoeb/byoeb/background_jobs/message_leaderboard/leaderboard.py
@@ -1,6 +1,8 @@
 import asyncio
 import json
 import os
+import logging
+import sys
 from datetime import datetime, timedelta, timezone
 from zoneinfo import ZoneInfo
 from typing import Dict, Any, List, Optional
@@ -20,9 +22,21 @@ IST = ZoneInfo("Asia/Kolkata")
 run_logger = AppInsightsLogHandler.getLogger("leaderboard_run")
 send_logger = AppInsightsLogHandler.getLogger("leaderboard_send")
 
+# Console Logger for local development and production console output
+console_logger = logging.getLogger("leaderboard_console")
+console_logger.setLevel(logging.INFO)
+# Only add handler if it doesn't already exist
+if not console_logger.handlers:
+    console_handler = logging.StreamHandler(sys.stdout)
+    console_handler.setLevel(logging.INFO)
+    formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s", datefmt="%Y-%m-%d %H:%M:%S")
+    console_handler.setFormatter(formatter)
+    console_logger.addHandler(console_handler)
+    console_logger.propagate = False
+
 # TEST MODE: Set to True to send only to your test phone number
 # Set to False to send to all users (production mode)
-TEST_MODE_SEND_TO_ME_ONLY = True  # Set to True for testing, False for production
+TEST_MODE_SEND_TO_ME_ONLY = False  # Set to True for testing, False for production
 
 # Your test phone number (read from keys.env using PHONE_NUMBER_ID)
 TEST_PHONE_NUMBER = os.getenv("PHONE_NUMBER_ID") if TEST_MODE_SEND_TO_ME_ONLY else None
@@ -509,7 +523,7 @@ async def send_leaderboard_template_messages(
     
     # Pre-calculate block leaderboards for all districts in a single optimized pass
     # This fetches messages and hydrates users once, then computes all district block leaderboards
-    print(f"\n📊 Pre-calculating block leaderboards for all districts in a single pass...")
+    console_logger.info("📊 Pre-calculating block leaderboards for all districts in a single pass...")
     run_logger.info("Pre-calculating block leaderboards", extra={AppInsightsLogHandler.DETAILS: {
         "context": "pre_calculate_block_leaderboards_optimized"
     }})
@@ -544,7 +558,7 @@ async def send_leaderboard_template_messages(
                 block_leaderboard_cache[district] = None
         
         successful_districts = len([v for v in block_leaderboard_cache.values() if v is not None])
-        print(f"   ✅ Calculated {successful_districts}/{len(unique_districts)} district block leaderboards (optimized single-pass)")
+        console_logger.info(f"✅ Calculated {successful_districts}/{len(unique_districts)} district block leaderboards (optimized single-pass)")
         run_logger.info("Block leaderboard cache ready", extra={AppInsightsLogHandler.DETAILS: {
             "context": "block_leaderboard_cache_ready",
             "successful_districts": successful_districts,
@@ -558,7 +572,7 @@ async def send_leaderboard_template_messages(
             "error": str(e)
         }})
         block_leaderboard_cache = {}  # Empty cache, will fall back to global leaderboard
-        print(f"   ⚠️  Error building block leaderboards: {str(e)}")
+        console_logger.warning(f"⚠️  Error building block leaderboards: {str(e)}")
     
     results = []
     sent_count = 0
@@ -802,7 +816,7 @@ async def send_leaderboard_template_messages(
                     
                     # Show progress every 10 messages
                     if len(results) % 10 == 0:
-                        print(f"   Progress: {sent_count} sent, {error_count} errors ({len(results)}/{len(phone_numbers)})")
+                        console_logger.info(f"Progress: {sent_count} sent, {error_count} errors ({len(results)}/{len(phone_numbers)})")
                 else:
                     error_count += 1
                     send_logger.error("No response from WhatsApp API", extra={AppInsightsLogHandler.DETAILS: {
@@ -844,17 +858,17 @@ async def send_leaderboard_template_messages(
                 "message": str(e)
             })
     
-    # Print final summary
-    print(f"\n📊 Sending Summary:")
-    print(f"   ✅ Successfully sent: {sent_count}/{len(phone_numbers)}")
-    print(f"   ❌ Errors: {error_count}/{len(phone_numbers)}")
+    # Log final summary
+    console_logger.info("📊 Sending Summary:")
+    console_logger.info(f"✅ Successfully sent: {sent_count}/{len(phone_numbers)}")
+    console_logger.info(f"❌ Errors: {error_count}/{len(phone_numbers)}")
     
     return results
 
 async def main():
-    print("\n" + "="*70)
-    print("🏆 LEADERBOARD MESSAGE SENDER".center(70))
-    print("="*70)
+    console_logger.info("="*70)
+    console_logger.info("🏆 LEADERBOARD MESSAGE SENDER".center(70))
+    console_logger.info("="*70)
     
     run_logger.info("Starting leaderboard job", extra={AppInsightsLogHandler.DETAILS: {
         "context": "leaderboard_job_start",
@@ -863,13 +877,13 @@ async def main():
     }})
     
     # Build global district leaderboard (used as fallback for users without location info)
-    print("\n📊 Building global district leaderboard...")
+    console_logger.info("📊 Building global district leaderboard...")
     leaderboard_df = await build_district_leaderboard_last_week_ist()
     top3_df = leaderboard_df.head(3)
-    print(f"   ✅ Found {len(leaderboard_df)} districts with activity")
-    print(f"\n   Top 3 Districts (Global):")
+    console_logger.info(f"✅ Found {len(leaderboard_df)} districts with activity")
+    console_logger.info("Top 3 Districts (Global):")
     for idx, row in top3_df.iterrows():
-        print(f"      {idx+1}. {row['district']}: {row['message_count']} messages, {row['unique_users']} users")
+        console_logger.info(f"   {idx+1}. {row['district']}: {row['message_count']} messages, {row['unique_users']} users")
     
     run_logger.info("Global district leaderboard built", extra={AppInsightsLogHandler.DETAILS: {
         "context": "build_global_leaderboard",
@@ -877,34 +891,34 @@ async def main():
         "top3_districts": top3_df.to_dict('records') if len(top3_df) > 0 else []
     }})
 
-    print(f"\n📝 Message Configuration:")
-    print(f"   Template: leaderboardv2")
-    print(f"   Parameters: 10 (3 items × 3 fields + type indicator)")
-    print(f"   Languages: Translated per user (en, hi, mr, te)")
-    print(f"\n📍 Personalization:")
-    print(f"   • Users WITH district & block → Top 3 blocks in their district")
-    print(f"   • Users WITHOUT location → Top 3 districts (global)")
+    console_logger.info("📝 Message Configuration:")
+    console_logger.info("   Template: leaderboardv2")
+    console_logger.info("   Parameters: 10 (3 items × 3 fields + type indicator)")
+    console_logger.info("   Languages: Translated per user (en, hi, mr, te)")
+    console_logger.info("📍 Personalization:")
+    console_logger.info("   • Users WITH district & block → Top 3 blocks in their district")
+    console_logger.info("   • Users WITHOUT location → Top 3 districts (global)")
     
     # Collect phone numbers based on mode
-    print("\n" + "="*70)
+    console_logger.info("="*70)
     if TEST_MODE_SEND_TO_ME_ONLY:
         if not TEST_PHONE_NUMBER:
-            print(f"❌ ERROR: TEST_MODE_SEND_TO_ME_ONLY is True but PHONE_NUMBER_ID not set")
-            print(f"   Please add PHONE_NUMBER_ID=your_phone_number to keys.env")
+            console_logger.error("❌ ERROR: TEST_MODE_SEND_TO_ME_ONLY is True but PHONE_NUMBER_ID not set")
+            console_logger.error("   Please add PHONE_NUMBER_ID=your_phone_number to keys.env")
             return
         
-        print(f"🧪 TEST MODE ENABLED")
-        print(f"   Recipient: {TEST_PHONE_NUMBER}")
-        print(f"   Count: 1 user (test only)")
+        console_logger.info("🧪 TEST MODE ENABLED")
+        console_logger.info(f"   Recipient: {TEST_PHONE_NUMBER}")
+        console_logger.info("   Count: 1 user (test only)")
         phone_numbers = [TEST_PHONE_NUMBER]
         mode = "test"
     else:
-        print(f"🚀 PRODUCTION MODE ENABLED")
+        console_logger.info("🚀 PRODUCTION MODE ENABLED")
         phone_numbers = await fetch_phone_numbers_for_asha_and_test_users()
-        print(f"   Recipients: {len(phone_numbers)} users")
+        console_logger.info(f"   Recipients: {len(phone_numbers)} users")
         mode = "production"
     
-    print("="*70)
+    console_logger.info("="*70)
     
     # Send messages to collected phone numbers
     results = await send_leaderboard_template_messages(
@@ -918,16 +932,16 @@ async def main():
     success_count = sum(1 for r in results if r.get("status") == "success")
     failure_count = len(results) - success_count
     
-    print("\n" + "="*70)
-    print("📈 FINAL RESULTS".center(70))
-    print("="*70)
-    print(f"   Total: {len(results)} messages")
-    print(f"   ✅ Success: {success_count}")
-    print(f"   ❌ Failed: {failure_count}")
-    print(f"   Mode: {mode.upper()}")
+    console_logger.info("="*70)
+    console_logger.info("📈 FINAL RESULTS".center(70))
+    console_logger.info("="*70)
+    console_logger.info(f"   Total: {len(results)} messages")
+    console_logger.info(f"   ✅ Success: {success_count}")
+    console_logger.info(f"   ❌ Failed: {failure_count}")
+    console_logger.info(f"   Mode: {mode.upper()}")
     if TEST_MODE_SEND_TO_ME_ONLY:
-        print(f"\n   💡 Tip: Set TEST_MODE_SEND_TO_ME_ONLY = False for production")
-    print("="*70 + "\n")
+        console_logger.info("   💡 Tip: Set TEST_MODE_SEND_TO_ME_ONLY = False for production")
+    console_logger.info("="*70)
     
     # Log completion
     log_details = {

--- a/byoeb-v1/byoeb/byoeb/background_jobs/message_leaderboard/leaderboard.py
+++ b/byoeb-v1/byoeb/byoeb/background_jobs/message_leaderboard/leaderboard.py
@@ -46,53 +46,19 @@ def validate_and_format_phone_number(phone: str) -> Optional[str]:
     
     # Check length (WhatsApp requires 11-13 digits with country code)
     if len(digits_only) < 11 or len(digits_only) > 13:
-        print(f"⚠️  Invalid phone number length: {phone} -> {digits_only} ({len(digits_only)} digits)")
-        print(f"   Expected: 11-13 digits (country code + number)")
         return None
     
     # Common validation: India numbers should start with 91
     if digits_only.startswith('91') and len(digits_only) == 12:
         return digits_only
     elif len(digits_only) == 10:
-        # Missing country code for India
-        print(f"⚠️  Phone number missing country code: {phone}")
-        print(f"   Adding India country code (91)...")
+        # Missing country code for India - add it
         return "91" + digits_only
     elif len(digits_only) >= 11:
         return digits_only
     
     return None
 
-def print_delivery_troubleshooting(phone: str, message_id: str, status: str):
-    """
-    Print troubleshooting information for message delivery issues.
-    """
-    phone_digits = re.sub(r'\D', '', phone)
-    phone_length = len(phone_digits)
-    
-    print(f"\n🔍 TROUBLESHOOTING for {phone}:")
-    print(f"   Message ID: {message_id}")
-    print(f"   API Status: {status}")
-    print(f"\n   Common reasons messages aren't delivered:")
-    print(f"   1. Phone number not registered with WhatsApp")
-    print(f"      → Verify {phone} has WhatsApp installed and active")
-    print(f"   2. Phone number format issue")
-    print(f"      → Current format: {phone} ({phone_length} digits)")
-    print(f"      → Should be: country code + number (11-13 digits, no + or spaces)")
-    print(f"   3. Template not fully approved")
-    print(f"      → Check WhatsApp Business Manager for template status")
-    print(f"   4. Delivery delay")
-    print(f"      → Template messages can take 1-5 minutes to deliver")
-    print(f"   5. Number not in business contact list")
-    print(f"      → Some accounts require numbers to be added first")
-    print(f"   6. Check WhatsApp Business Manager")
-    print(f"      → Go to Message Templates → View delivery reports")
-    print(f"      → Look for message ID: {message_id}")
-    print(f"\n   Next steps:")
-    print(f"   - Wait 5-10 minutes and check WhatsApp again")
-    print(f"   - Verify phone number format is correct")
-    print(f"   - Check if template is fully approved (not just 'Active')")
-    print(f"   - Try sending to a number that previously received messages")
 
 def get_user_district(user) -> Optional[str]:
     """
@@ -491,7 +457,7 @@ async def send_leaderboard_template_messages(
             if district:
                 unique_districts.add(district.strip().lower())
     
-    print(f"\n📊 Pre-calculating block leaderboards for {len(unique_districts)} unique districts...")
+    print(f"\n📊 Pre-calculating block leaderboards for {len(unique_districts)} districts...")
     run_logger.info("Pre-calculating block leaderboards", extra={AppInsightsLogHandler.DETAILS: {
         "context": "pre_calculate_block_leaderboards",
         "unique_districts_count": len(unique_districts),
@@ -501,21 +467,18 @@ async def send_leaderboard_template_messages(
     block_leaderboard_cache = {}
     for district in unique_districts:
         try:
-            print(f"   Calculating block leaderboard for district: {district}")
             block_df = await build_block_leaderboard_for_district(
                 district=district,
                 message_categories=None,
                 processing_batch_size=1000
             )
             block_leaderboard_cache[district] = block_df
-            print(f"   ✅ Found {len(block_df)} blocks for {district}")
             run_logger.info(f"Block leaderboard calculated for district", extra={AppInsightsLogHandler.DETAILS: {
                 "context": "build_block_leaderboard",
                 "district": district,
                 "blocks_found": len(block_df)
             }})
         except Exception as e:
-            print(f"   ⚠️  Error building block leaderboard for {district}: {e}")
             block_leaderboard_cache[district] = None  # Cache None to avoid retrying
             run_logger.error(f"Error building block leaderboard for district", extra={AppInsightsLogHandler.DETAILS: {
                 "context": "build_block_leaderboard_error",
@@ -524,7 +487,7 @@ async def send_leaderboard_template_messages(
             }})
     
     successful_districts = len([v for v in block_leaderboard_cache.values() if v is not None])
-    print(f"✅ Block leaderboard cache ready with {successful_districts} districts\n")
+    print(f"   ✅ Calculated {successful_districts}/{len(unique_districts)} district block leaderboards")
     run_logger.info("Block leaderboard cache ready", extra={AppInsightsLogHandler.DETAILS: {
         "context": "block_leaderboard_cache_ready",
         "successful_districts": successful_districts,
@@ -532,12 +495,15 @@ async def send_leaderboard_template_messages(
     }})
     
     results = []
+    sent_count = 0
+    error_count = 0
+    
     for phone in phone_numbers:
         try:
             # Validate and format phone number
             formatted_phone = validate_and_format_phone_number(phone)
             if not formatted_phone:
-                print(f"❌ Invalid phone number format: {phone}")
+                error_count += 1
                 send_logger.warning("Invalid phone number format", extra={AppInsightsLogHandler.DETAILS: {
                     "context": "validate_phone_number",
                     "phone": phone,
@@ -551,7 +517,6 @@ async def send_leaderboard_template_messages(
                 continue
             
             if formatted_phone != phone:
-                print(f"📞 Phone number formatted: {phone} → {formatted_phone}")
                 phone = formatted_phone  # Use formatted version
             
             # Get user language, default to 'en' if user not found
@@ -575,7 +540,6 @@ async def send_leaderboard_template_messages(
                         if cached_block_df is not None and len(cached_block_df) > 0:
                             user_leaderboard_df = cached_block_df
                             is_block_leaderboard = True
-                            print(f"📍 User {phone} → Using cached block leaderboard for district {user_district} ({len(cached_block_df)} blocks)")
                             send_logger.debug("Using block leaderboard for user", extra={AppInsightsLogHandler.DETAILS: {
                                 "context": "user_block_leaderboard",
                                 "phone": phone,
@@ -584,7 +548,6 @@ async def send_leaderboard_template_messages(
                                 "blocks_count": len(cached_block_df)
                             }})
                         else:
-                            print(f"📍 User {phone} → No blocks found for district {user_district}, using global leaderboard")
                             send_logger.debug("No blocks found, using global leaderboard", extra={AppInsightsLogHandler.DETAILS: {
                                 "context": "user_fallback_global",
                                 "phone": phone,
@@ -593,7 +556,6 @@ async def send_leaderboard_template_messages(
                                 "reason": "no_blocks_found"
                             }})
                     else:
-                        print(f"📍 User {phone} → District {user_district} not in cache, using global leaderboard")
                         send_logger.debug("District not in cache, using global leaderboard", extra={AppInsightsLogHandler.DETAILS: {
                             "context": "user_fallback_global",
                             "phone": phone,
@@ -602,7 +564,6 @@ async def send_leaderboard_template_messages(
                             "reason": "not_in_cache"
                         }})
                 else:
-                    print(f"📍 User {phone} → Has location info but no district, using global leaderboard")
                     send_logger.debug("User has location but no district", extra={AppInsightsLogHandler.DETAILS: {
                         "context": "user_fallback_global",
                         "phone": phone,
@@ -610,7 +571,6 @@ async def send_leaderboard_template_messages(
                         "reason": "no_district"
                     }})
             else:
-                print(f"📍 User {phone} → No location info, using global district leaderboard")
                 send_logger.debug("User has no location info", extra={AppInsightsLogHandler.DETAILS: {
                     "context": "user_fallback_global",
                     "phone": phone,
@@ -627,21 +587,24 @@ async def send_leaderboard_template_messages(
             
             # Validate template parameters before sending (always expect 10 parameters)
             if not template_parameters or len(template_parameters) != 10:
-                print(f"❌ ERROR: Invalid template parameters for {phone}")
-                print(f"   Expected 10 parameters, got: {len(template_parameters) if template_parameters else 0}")
-                print(f"   Parameters: {template_parameters}")
+                error_count += 1
+                send_logger.error("Invalid template parameters", extra={AppInsightsLogHandler.DETAILS: {
+                    "context": "invalid_template_params",
+                    "phone": phone,
+                    "user_id": user.user_id if user else None,
+                    "expected": 10,
+                    "got": len(template_parameters) if template_parameters else 0
+                }})
                 continue
             
             # Ensure all parameters are non-empty strings (no None or empty values)
             validated_parameters = []
             for i, param in enumerate(template_parameters):
                 if param is None:
-                    print(f"⚠️  WARNING: Parameter {i+1} is None, replacing with 'N/A'")
                     validated_parameters.append("N/A")
                 elif not isinstance(param, str):
                     validated_parameters.append(str(param) if param else "N/A")
                 elif len(param.strip()) == 0:
-                    print(f"⚠️  WARNING: Parameter {i+1} is empty, replacing with 'N/A'")
                     validated_parameters.append("N/A")
                 else:
                     validated_parameters.append(param.strip())
@@ -699,15 +662,6 @@ async def send_leaderboard_template_messages(
             # Prepare requests - this will create both text and template requests (like consensus does)
             requests = whatsapp_service.prepare_requests(byoeb_message)
             
-            # Debug: Show what requests were generated
-            print(f"\n🔍 DEBUG: Generated {len(requests)} request(s) for {phone}")
-            for i, req in enumerate(requests):
-                req_type = req.get("type", "unknown")
-                print(f"   Request {i}: type={req_type}")
-                if req_type == "template":
-                    print(f"      Template name: {req.get('template', {}).get('name', 'N/A')}")
-                    print(f"      Template language: {req.get('template', {}).get('language', {}).get('code', 'N/A')}")
-            
             # Select only the template request
             # prepare_requests returns: [text_message, template_message] when both are present
             # But we should find it by type, not by index, to be more robust
@@ -718,26 +672,20 @@ async def send_leaderboard_template_messages(
                     break
             
             if not template_request:
-                print(f"❌ ERROR: No template request found in {len(requests)} request(s) for {phone}")
-                print(f"   Request types: {[req.get('type', 'unknown') for req in requests]}")
+                error_count += 1
+                send_logger.error("No template request found", extra={AppInsightsLogHandler.DETAILS: {
+                    "context": "no_template_request",
+                    "phone": phone,
+                    "user_id": user.user_id if user else None,
+                    "request_types": [req.get('type', 'unknown') for req in requests]
+                }})
                 continue
             
             # Change message type to TEMPLATE_TEXT (like consensus does for inactive users)
             byoeb_message.message_context.message_type = MessageTypes.TEMPLATE_TEXT.value
             
-            # Verify template request is correct
+            # Send only the template request (like consensus does for inactive users)
             if template_request:
-                print(f"\n📤 Preparing to send template to {phone} (lang: {user_language})")
-                print(f"   Template: {constants.TEMPLATE_NAME}={byoeb_message.message_context.additional_info[constants.TEMPLATE_NAME]}")
-                print(f"   Parameters ({len(template_parameters)}): {template_parameters}")
-                print(f"   Parameter validation: All parameters are non-empty strings: {all(isinstance(p, str) and len(p) > 0 for p in template_parameters)}")
-                print(f"   Using 10 parameters: 3 items × (name, count, users) + type indicator")
-                
-                # Log the exact payload being sent (for debugging)
-                print(f"\n   📋 WhatsApp API Payload:")
-                print(f"      {json.dumps(template_request, indent=6)}")
-                
-                # Send only the template request (like consensus does for inactive users)
                 responses, message_ids = await whatsapp_service.send_requests([template_request])
                 
                 # Check response status
@@ -747,24 +695,16 @@ async def send_leaderboard_template_messages(
                     error = response.response_status.error if hasattr(response, 'response_status') and hasattr(response.response_status, 'error') else None
                     message_id = message_ids[0] if message_ids else None
                     
-                    print(f"   Response Status: {status}")
-                    if error and error != 'None':
-                        print(f"   ⚠️  Error: {error}")
-                    if message_id:
-                        print(f"   Message ID: {message_id}")
-                    
                     # Check message status
+                    msg_status = 'unknown'
                     if hasattr(response, 'messages') and response.messages:
                         msg_status = response.messages[0].message_status if hasattr(response.messages[0], 'message_status') else 'unknown'
-                        print(f"   Message Status: {msg_status}")
                         
-                        # Check if message was actually accepted
-                        if msg_status == 'accepted':
-                            print(f"✅ Template message accepted by WhatsApp API for {phone}")
-                            print(f"   ⏳ Delivery may take 1-5 minutes")
-                            print(f"   📱 Please check your WhatsApp after a few minutes")
-                            send_logger.info("Leaderboard message accepted by WhatsApp API", extra={AppInsightsLogHandler.DETAILS: {
-                                "context": "message_accepted",
+                        # Log based on message status
+                        if msg_status in ['accepted', 'sent', 'delivered', 'read']:
+                            sent_count += 1
+                            send_logger.info(f"Leaderboard message {msg_status}", extra={AppInsightsLogHandler.DETAILS: {
+                                "context": f"message_{msg_status}",
                                 "phone": phone,
                                 "user_id": user.user_id if user else None,
                                 "message_id": message_id,
@@ -772,38 +712,8 @@ async def send_leaderboard_template_messages(
                                 "is_block_leaderboard": is_block_leaderboard,
                                 "whatsapp_status": status
                             }})
-                            # Print troubleshooting info
-                            if message_id:
-                                print_delivery_troubleshooting(phone, message_id, status)
-                        elif msg_status == 'sent':
-                            print(f"✅ Template message sent to {phone}")
-                            send_logger.info("Leaderboard message sent", extra={AppInsightsLogHandler.DETAILS: {
-                                "context": "message_sent",
-                                "phone": phone,
-                                "user_id": user.user_id if user else None,
-                                "message_id": message_id,
-                                "language": user_language
-                            }})
-                        elif msg_status == 'delivered':
-                            print(f"✅✅ Message delivered to {phone}!")
-                            send_logger.info("Leaderboard message delivered", extra={AppInsightsLogHandler.DETAILS: {
-                                "context": "message_delivered",
-                                "phone": phone,
-                                "user_id": user.user_id if user else None,
-                                "message_id": message_id,
-                                "language": user_language
-                            }})
-                        elif msg_status == 'read':
-                            print(f"✅✅✅ Message read by {phone}!")
-                            send_logger.info("Leaderboard message read", extra={AppInsightsLogHandler.DETAILS: {
-                                "context": "message_read",
-                                "phone": phone,
-                                "user_id": user.user_id if user else None,
-                                "message_id": message_id,
-                                "language": user_language
-                            }})
                         else:
-                            print(f"⚠️  Message status: {msg_status} (may indicate delivery issue)")
+                            error_count += 1
                             send_logger.warning("Leaderboard message status issue", extra={AppInsightsLogHandler.DETAILS: {
                                 "context": "message_status_warning",
                                 "phone": phone,
@@ -813,8 +723,6 @@ async def send_leaderboard_template_messages(
                                 "whatsapp_status": status,
                                 "error": error
                             }})
-                            if message_id:
-                                print_delivery_troubleshooting(phone, message_id, status)
                     
                     results.append({
                         "phone": phone,
@@ -825,8 +733,12 @@ async def send_leaderboard_template_messages(
                         "message_status": msg_status if 'msg_status' in locals() else None,
                         "error": error if error and error != 'None' else None
                     })
+                    
+                    # Show progress every 10 messages
+                    if len(results) % 10 == 0:
+                        print(f"   Progress: {sent_count} sent, {error_count} errors ({len(results)}/{len(phone_numbers)})")
                 else:
-                    print(f"❌ No response received from WhatsApp API for {phone}")
+                    error_count += 1
                     send_logger.error("No response from WhatsApp API", extra={AppInsightsLogHandler.DETAILS: {
                         "context": "no_whatsapp_response",
                         "phone": phone,
@@ -839,7 +751,7 @@ async def send_leaderboard_template_messages(
                         "message": "No response from WhatsApp API"
                     })
             else:
-                print(f"❌ Failed to prepare template request for {phone}")
+                error_count += 1
                 send_logger.error("Failed to prepare template request", extra={AppInsightsLogHandler.DETAILS: {
                     "context": "prepare_request_failed",
                     "phone": phone,
@@ -852,7 +764,7 @@ async def send_leaderboard_template_messages(
                     "message": "Failed to prepare request"
                 })
         except Exception as e:
-            print(f"❌ Error sending to {phone}: {str(e)}")
+            error_count += 1
             send_logger.error("Error sending leaderboard message", extra={AppInsightsLogHandler.DETAILS: {
                 "context": "send_error",
                 "phone": phone,
@@ -866,9 +778,18 @@ async def send_leaderboard_template_messages(
                 "message": str(e)
             })
     
+    # Print final summary
+    print(f"\n📊 Sending Summary:")
+    print(f"   ✅ Successfully sent: {sent_count}/{len(phone_numbers)}")
+    print(f"   ❌ Errors: {error_count}/{len(phone_numbers)}")
+    
     return results
 
 async def main():
+    print("\n" + "="*70)
+    print("🏆 LEADERBOARD MESSAGE SENDER".center(70))
+    print("="*70)
+    
     run_logger.info("Starting leaderboard job", extra={AppInsightsLogHandler.DETAILS: {
         "context": "leaderboard_job_start",
         "test_mode": TEST_MODE_SEND_TO_ME_ONLY,
@@ -876,9 +797,13 @@ async def main():
     }})
     
     # Build global district leaderboard (used as fallback for users without location info)
+    print("\n📊 Building global district leaderboard...")
     leaderboard_df = await build_district_leaderboard_last_week_ist()
     top3_df = leaderboard_df.head(3)
-    print("\nTop 3 Districts (Global - used for users without location info):\n", top3_df.to_string(index=False))
+    print(f"   ✅ Found {len(leaderboard_df)} districts with activity")
+    print(f"\n   Top 3 Districts (Global):")
+    for idx, row in top3_df.iterrows():
+        print(f"      {idx+1}. {row['district']}: {row['message_count']} messages, {row['unique_users']} users")
     
     run_logger.info("Global district leaderboard built", extra={AppInsightsLogHandler.DETAILS: {
         "context": "build_global_leaderboard",
@@ -886,39 +811,36 @@ async def main():
         "top3_districts": top3_df.to_dict('records') if len(top3_df) > 0 else []
     }})
 
-    # Display what will be sent (sample for global leaderboard)
-    # Note: In actual sending, each user gets their own language-specific translation
-    template_params = await format_leaderboard_as_template_parameters(top3_df, user_language="en")
-    print(f"\nSample Template Parameters (Global Districts, English): {template_params}")
-    print(f"   Note: 10th parameter will be translated based on each user's language")
-    print(f"Template Name: leaderboardv2")
-    print(f"\n📌 PERSONALIZATION LOGIC:")
-    print(f"   - Users WITH district & block info → Top 3 blocks in their district")
-    print(f"   - Users WITHOUT location info → Top 3 districts (global)")
-    print(f"📊 Using 10 parameters: 3 items × (name, count, users) + type indicator")
+    print(f"\n📝 Message Configuration:")
+    print(f"   Template: leaderboardv2")
+    print(f"   Parameters: 10 (3 items × 3 fields + type indicator)")
+    print(f"   Languages: Translated per user (en, hi, mr, te)")
+    print(f"\n📍 Personalization:")
+    print(f"   • Users WITH district & block → Top 3 blocks in their district")
+    print(f"   • Users WITHOUT location → Top 3 districts (global)")
     
     # Collect phone numbers based on mode
+    print("\n" + "="*70)
     if TEST_MODE_SEND_TO_ME_ONLY:
         if not TEST_PHONE_NUMBER:
-            print(f"\n❌ ERROR: TEST_MODE_SEND_TO_ME_ONLY is True but PHONE_NUMBER_ID is not set in keys.env")
-            print(f"   Please add PHONE_NUMBER_ID=your_phone_number to your keys.env file")
+            print(f"❌ ERROR: TEST_MODE_SEND_TO_ME_ONLY is True but PHONE_NUMBER_ID not set")
+            print(f"   Please add PHONE_NUMBER_ID=your_phone_number to keys.env")
             return
         
-        print(f"\n🧪 TEST MODE: Sending template message only to {TEST_PHONE_NUMBER}")
-        print(f"   ✅ SAFETY CHECK: TEST_MODE_SEND_TO_ME_ONLY = True")
-        print(f"   ✅ Only 1 recipient will receive the message")
+        print(f"🧪 TEST MODE ENABLED")
+        print(f"   Recipient: {TEST_PHONE_NUMBER}")
+        print(f"   Count: 1 user (test only)")
         phone_numbers = [TEST_PHONE_NUMBER]
         mode = "test"
     else:
-        print(f"\n⚠️  WARNING: PRODUCTION MODE ACTIVE!")
-        print(f"   TEST_MODE_SEND_TO_ME_ONLY = False")
-        print(f"   Messages will be sent to ALL users")
+        print(f"🚀 PRODUCTION MODE ENABLED")
         phone_numbers = await fetch_phone_numbers_for_asha_and_test_users()
-        print(f"Total recipients found: {len(phone_numbers)}")
+        print(f"   Recipients: {len(phone_numbers)} users")
         mode = "production"
     
+    print("="*70)
+    
     # Send messages to collected phone numbers
-    print(f"\n🚀 Sending template messages to {len(phone_numbers)} users")
     results = await send_leaderboard_template_messages(
         phone_numbers, 
         top3_df, 
@@ -929,11 +851,17 @@ async def main():
     # Calculate and report results
     success_count = sum(1 for r in results if r.get("status") == "success")
     failure_count = len(results) - success_count
-    print(f"\n✅ Successfully sent {success_count} out of {len(results)} messages")
     
+    print("\n" + "="*70)
+    print("📈 FINAL RESULTS".center(70))
+    print("="*70)
+    print(f"   Total: {len(results)} messages")
+    print(f"   ✅ Success: {success_count}")
+    print(f"   ❌ Failed: {failure_count}")
+    print(f"   Mode: {mode.upper()}")
     if TEST_MODE_SEND_TO_ME_ONLY:
-        print(f"\n⚠️  TEST MODE ACTIVE: Only sent to test phone number")
-        print(f"   To enable production mode, set TEST_MODE_SEND_TO_ME_ONLY = False")
+        print(f"\n   💡 Tip: Set TEST_MODE_SEND_TO_ME_ONLY = False for production")
+    print("="*70 + "\n")
     
     # Log completion
     log_details = {

--- a/byoeb-v1/byoeb/byoeb/background_jobs/message_leaderboard/leaderboard.py
+++ b/byoeb-v1/byoeb/byoeb/background_jobs/message_leaderboard/leaderboard.py
@@ -3,6 +3,7 @@ import json
 import os
 import logging
 import sys
+from pathlib import Path
 from datetime import datetime, timedelta, timezone
 from zoneinfo import ZoneInfo
 from typing import Dict, Any, List, Optional
@@ -74,33 +75,46 @@ def validate_and_format_phone_number(phone: str) -> Optional[str]:
     
     return None
 
+# Load translations from JSON file
+def _load_leaderboard_translations() -> Dict[str, Dict[str, str]]:
+    """
+    Load leaderboard translations from translate.json file in utils folder.
+    
+    Returns:
+        Dictionary with language codes as keys and translation dictionaries as values
+    """
+    # Get the path to translate.json relative to this file (similar to bot_config.json pattern)
+    current_dir = Path(__file__).resolve().parent
+    translate_file_path = current_dir / ".." / ".." / "utils" / "translate.json"
+    translate_file_path = translate_file_path.resolve()
+    
+    try:
+        translations = json.loads(translate_file_path.read_text(encoding="utf-8"))
+        return translations
+    except FileNotFoundError:
+        console_logger.error(f"Translation file not found at {translate_file_path}. Using default English translations.")
+        # Return default English translations as fallback
+        return {
+            "en": {
+                "block_singular": "Block ",
+                "district_singular": "District ",
+                "blocks_plural": "Blocks",
+                "districts_plural": "Districts"
+            }
+        }
+    except json.JSONDecodeError as e:
+        console_logger.error(f"Error parsing translation file: {e}. Using default English translations.")
+        return {
+            "en": {
+                "block_singular": "Block ",
+                "district_singular": "District ",
+                "blocks_plural": "Blocks",
+                "districts_plural": "Districts"
+            }
+        }
+
 # Unified translation dictionary for leaderboard text
-LEADERBOARD_TRANSLATIONS = {
-    "en": {
-        "block_singular": "Block ",      # With trailing space for prefixing
-        "district_singular": "District ",
-        "blocks_plural": "Blocks",
-        "districts_plural": "Districts"
-    },
-    "hi": {
-        "block_singular": "ब्लॉक ",
-        "district_singular": "जिला ",
-        "blocks_plural": "ब्लॉक",
-        "districts_plural": "जिले"
-    },
-    "mr": {
-        "block_singular": "ब्लॉक ",
-        "district_singular": "जिल्हा ",
-        "blocks_plural": "ब्लॉक",
-        "districts_plural": "जिल्हे"
-    },
-    "te": {
-        "block_singular": "బ్లాక్ ",
-        "district_singular": "జిల్లా ",
-        "blocks_plural": "బ్లాక్‌లు",
-        "districts_plural": "జిల్లాలు"
-    }
-}
+LEADERBOARD_TRANSLATIONS = _load_leaderboard_translations()
 
 def get_leaderboard_translation(is_block_leaderboard: bool, user_language: str = "en", plural: bool = False) -> str:
     """

--- a/byoeb-v1/byoeb/byoeb/repositories/message_repository.py
+++ b/byoeb-v1/byoeb/byoeb/repositories/message_repository.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import AsyncIterator, Dict, Any, Optional
+from typing import AsyncIterator, Dict, Any, Optional, List, Tuple
 
 from byoeb.repositories.base_repository import BaseRepository
 
@@ -11,8 +11,9 @@ class MessageRepository(BaseRepository, ABC):
                                         start_timestamp: int, 
                                         end_timestamp: int,
                                         message_categories: Optional[list[str]] = None,
-                                        projection: Optional[Dict[str, Any]] = None) -> AsyncIterator[Dict[str, Any]]:
-        """Stream messages within a specific time range with optional category filtering."""
+                                        projection: Optional[Dict[str, Any]] = None,
+                                        sort: Optional[List[Tuple[str, int]]] = None) -> AsyncIterator[Dict[str, Any]]:
+        """Stream messages within a specific time range with optional category filtering and sorting."""
         pass
 
     @abstractmethod

--- a/byoeb-v1/byoeb/byoeb/repositories/mongodb_message_repository.py
+++ b/byoeb-v1/byoeb/byoeb/repositories/mongodb_message_repository.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any, Optional, AsyncIterator
+from typing import Dict, Any, Optional, AsyncIterator, List, Tuple
 from byoeb.repositories.message_repository import MessageRepository
 from byoeb.repositories.mongodb_base_repository import MongoBaseRepository
 
@@ -8,7 +8,8 @@ class MongoMessageRepository(MessageRepository, MongoBaseRepository):
                                         start_timestamp: int, 
                                         end_timestamp: int,
                                         message_categories: Optional[list[str]] = None,
-                                        projection: Optional[Dict[str, Any]] = None) -> AsyncIterator[Dict[str, Any]]:
+                                        projection: Optional[Dict[str, Any]] = None,
+                                        sort: Optional[List[Tuple[str, int]]] = None) -> AsyncIterator[Dict[str, Any]]:
         filter_dict = {
             "message_data.incoming_timestamp": {
                 "$gte": start_timestamp, 
@@ -19,7 +20,7 @@ class MongoMessageRepository(MessageRepository, MongoBaseRepository):
         if message_categories:
             filter_dict["message_data.message_category"] = {"$in": message_categories}
 
-        return self.find_all(filter_dict, projection)
+        return self.find_all(filter_dict, projection, sort=sort)
 
     async def find_messages_by_user_ids(self, 
                                       user_ids: list[str],

--- a/byoeb-v1/byoeb/byoeb/services/databases/mongo_db/message_db.py
+++ b/byoeb-v1/byoeb/byoeb/services/databases/mongo_db/message_db.py
@@ -41,7 +41,7 @@ class MessageMongoDBService(BaseMongoDBService):
             return None
         loc = getattr(user_obj, "user_location", None) or {}
         dist = loc.get("district") if hasattr(loc, "get") else getattr(loc, "district", None)
-        return str(dist).strip() if dist and str(dist).strip().lower() != "unknown" else None
+        return str(dist).strip().title() if dist and str(dist).strip().lower() != "unknown" else None
 
     async def build_district_leaderboard(
         self, 

--- a/byoeb-v1/byoeb/byoeb/services/user/utils.py
+++ b/byoeb-v1/byoeb/byoeb/services/user/utils.py
@@ -1,6 +1,6 @@
 import hashlib
 from byoeb_core.models.byoeb.user import User
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Optional
 
 def get_experts_numbers(
     experts: Dict[str, List[str]]
@@ -82,3 +82,63 @@ def get_delete_messages(
                 "message": "Deleted successfully"
             })
     return messages
+
+def get_user_district(user) -> Optional[str]:
+    """
+    Extract district from user object.
+    
+    Args:
+        user: User object (can be None, dict, or object with user_location attribute)
+        
+    Returns:
+        Optional[str]: District name or None if not found/unknown
+    """
+    if not user:
+        return None
+    loc = getattr(user, "user_location", None) or {}
+    if isinstance(loc, dict):
+        dist = loc.get("district") or loc.get("District")
+    else:
+        dist = getattr(loc, "district", None) or getattr(loc, "District", None)
+    if dist:
+        dist_str = str(dist).strip()
+        if dist_str.lower() not in ["unknown", "none", ""]:
+            return dist_str.title()
+    return None
+
+def get_user_block(user) -> Optional[str]:
+    """
+    Extract block from user object.
+    
+    Args:
+        user: User object (can be None, dict, or object with user_location attribute)
+        
+    Returns:
+        Optional[str]: Block name or None if not found/unknown
+    """
+    if not user:
+        return None
+    loc = getattr(user, "user_location", None) or {}
+    if isinstance(loc, dict):
+        block = loc.get("block") or loc.get("Block")
+    else:
+        block = getattr(loc, "block", None) or getattr(loc, "Block", None)
+    if block:
+        block_str = str(block).strip()
+        if block_str.lower() not in ["unknown", "none", ""]:
+            return block_str.title()
+    return None
+
+def has_location_info(user) -> bool:
+    """
+    Check if user has valid district and block information.
+    
+    Args:
+        user: User object
+        
+    Returns:
+        bool: True if user has both district and block, False otherwise
+    """
+    district = get_user_district(user)
+    block = get_user_block(user)
+    return district is not None and block is not None

--- a/byoeb-v1/byoeb/byoeb/utils/translate.json
+++ b/byoeb-v1/byoeb/byoeb/utils/translate.json
@@ -1,0 +1,27 @@
+{
+  "en": {
+    "block_singular": "Block ",
+    "district_singular": "District ",
+    "blocks_plural": "Blocks",
+    "districts_plural": "Districts"
+  },
+  "hi": {
+    "block_singular": "ब्लॉक ",
+    "district_singular": "जिला ",
+    "blocks_plural": "ब्लॉक",
+    "districts_plural": "जिले"
+  },
+  "mr": {
+    "block_singular": "ब्लॉक ",
+    "district_singular": "जिल्हा ",
+    "blocks_plural": "ब्लॉक",
+    "districts_plural": "जिल्हे"
+  },
+  "te": {
+    "block_singular": "బ్లాక్ ",
+    "district_singular": "జిల్లా ",
+    "blocks_plural": "బ్లాక్‌లు",
+    "districts_plural": "జిల్లాలు"
+  }
+}
+


### PR DESCRIPTION
## Overview
Enhances leaderboard messages to be more engaging by showing personalized local competition data and respecting user language preferences.

## Key Changes
- **Personalized leaderboards**: Users with location data see top 3 blocks in their district; others see global top 3 districts
- **Multi-language support**: Translates prefixes and type indicators for Hindi, Marathi, and Telugu
- **Performance optimization**: Block leaderboards are cached per district
- **Azure App Insights logging**: Added comprehensive monitoring for job and message operations
- **Code cleanup**: Removed test mode parameters, moved test phone to environment variable

## Testing Locally

1. **Setup environment**
   # Add to keys.env
   PHONE_NUMBER_ID="your_phone_number"
   TEST_USERS_ONLY=true
   2. **Enable test mode** (line 24 in leaderboard.py)
   TEST_MODE_SEND_TO_ME_ONLY = True
   3. **Run the script**
   python byoeb-v1/byoeb/byoeb/background_jobs/message_leaderboard/leaderboard.py
