### PR TITLE
fix: make LLM answers deterministic via temperature=0 and stable chunk ordering

### DIFF
--- a/byoeb-v1/byoeb/byoeb/chat_app/configuration/dependency_setup.py
+++ b/byoeb-v1/byoeb/byoeb/chat_app/configuration/dependency_setup.py
@@ -331,14 +331,16 @@ llm_client = AsyncLLamaIndexOpenAILLM(
     model=app_config["llms"]["openai"]["model"],
     api_key=env_config.env_openai_api_key,
     api_version=app_config["llms"]["openai"]["api_version"],
-    organization=env_config.env_openai_org_id
+    organization=env_config.env_openai_org_id,
+    temperature=0.0  # Set to 0 for deterministic responses (same input → same output)
 )
 
 llm_translate_and_rewrite_client = AsyncLLamaIndexOpenAILLM(
     model=app_config["llms"]["openai"]["model"],
     api_key=env_config.env_openai_api_key,
     api_version=app_config["llms"]["openai"]["api_version"],
-    organization=env_config.env_openai_org_id
+    organization=env_config.env_openai_org_id,
+    temperature=0.0  # Set to 0 for deterministic query rewriting (same input → same output)
 )
 
 

--- a/byoeb-v1/byoeb/byoeb/services/chat/message_handlers/user_flow_handlers/generate.py
+++ b/byoeb-v1/byoeb/byoeb/services/chat/message_handlers/user_flow_handlers/generate.py
@@ -602,17 +602,20 @@ class ByoebUserGenerateResponse(Handler):
             return extracted_data["response_en"], extracted_data["response_src"]
 
         vector_search_queries = vector_search_queries or [(query, AzureVectorSearchType.HYBRID.value, 3)]
+        
         retrieved_chunks: dict[str, Chunk] = {}
         for chunks in await asyncio.gather(*(self.__aretrieve_chunks(q or query, k=k, search_type=t) for q, t, k in vector_search_queries)):
             for chunk in chunks:
                 retrieved_chunks[chunk.chunk_id] = chunk
 
-        retrieved_chunks_list = list(self.filter_retrieved_chunks(retrieved_chunks.values(), thresholds=bot_config["retrieval"]["similarity_thresholds"]))
+        # Sort chunks deterministically by chunk_id for consistent ordering (deterministic RAG)
+        sorted_chunks = sorted(retrieved_chunks.values(), key=lambda c: c.chunk_id)
+        retrieved_chunks_list = list(self.filter_retrieved_chunks(sorted_chunks, thresholds=bot_config["retrieval"]["similarity_thresholds"]))
         if not retrieved_chunks_list:
             return constants.IDK, constants.IDK, {}, list(retrieved_chunks.values())
 
-        update_kb_list = self._chunks_to_kb_topics(chunk for chunk in retrieved_chunks_list if "KB Updated" in chunk.metadata.source)
-        raw_kb_list = self._chunks_to_kb_topics(chunk for chunk in retrieved_chunks_list if "KB Updated" not in chunk.metadata.source)
+        update_kb_list = self._chunks_to_kb_topics(chunk for chunk in retrieved_chunks_list if chunk.metadata and "KB Updated" in chunk.metadata.source)
+        raw_kb_list = self._chunks_to_kb_topics(chunk for chunk in retrieved_chunks_list if not chunk.metadata or "KB Updated" not in chunk.metadata.source)
 
         system_prompt = self._get_system_prompt(user_language)
         template_user_prompt = bot_config["llm_response"]["answer_prompts"]["user_prompt"]
@@ -760,6 +763,7 @@ class ByoebUserGenerateResponse(Handler):
     ) -> List[ByoebMessageContext]:
         byoeb_messages = []
         message: ByoebMessageContext = messages[0].model_copy(deep=True)
+        
         read_reciept_message = self.__create_read_reciept_message(message)
         if message.reply_context.message_category == MessageCategory.AUDIO_IDK.value:
             related_questions = message.reply_context.additional_info.get(constants.RELATED_QUESTIONS)
@@ -846,11 +850,11 @@ class ByoebUserGenerateResponse(Handler):
             
             user_language = message.user.user_language
             query_type = message.message_context.additional_info.get(constants.QUERY_TYPE)
+            
             default_message_category = None
             cache_hit = False
 
             if embedding_fn and (FeatureFlag.CACHE_MESSAGES in feature_flags or message.user.test_user):
-                start_time = datetime.now(timezone.utc).timestamp()
                 embedding = await embedding_fn.aget_text_embedding(message_english)
                 end_time = datetime.now(timezone.utc).timestamp()
                 logger.debug("Generated cache embeddings in %ss", end_time - start_time)
@@ -863,7 +867,7 @@ class ByoebUserGenerateResponse(Handler):
                 embedding = None
                 cache_result = None, None, None
 
-            cache_val = cache_result[2]
+            cache_val = cache_result[2] if cache_result else None
             if cache_val and "answer" in cache_val and user_language in cache_val["answer"]:
                 response_en, response_source, related_questions, tokens = cache_val["answer"][user_language]
                 cache_hit = True
@@ -871,7 +875,9 @@ class ByoebUserGenerateResponse(Handler):
                 start_time = datetime.now(timezone.utc).timestamp()
                 skip_cache = True
                 retrieved_chunks_related_questions = asyncio.create_task(self._retrieve_top_k_chunks_for_related_questions(message_english, k=10))
+                
                 response_en, response_source, tokens, retrieved_chunks = await self.agenerate_answer(user_language, message_english, query_type)
+                
                 if not utils.is_idk(response_en):  # got answer on first try :)
                     skip_cache = False
                 else:
@@ -888,6 +894,7 @@ class ByoebUserGenerateResponse(Handler):
                         if not utils.is_idk(response_en2):
                             skip_cache = False
                             response_en, response_source, tokens = response_en2, response_source2, tokens2
+                            expansion_success = True
                             break
 
                 if utils.is_idk(response_en) and (FeatureFlag.QUERY_DISAMBIGUATION in feature_flags or message.user.test_user):
@@ -919,6 +926,7 @@ class ByoebUserGenerateResponse(Handler):
                     "time_taken": end_time - start_time,
                     **tokens
                 }})
+            
             byoeb_user_message = await self.__create_user_message(
                 message=message,
                 response_en=response_en,

--- a/byoeb-v1/byoeb/byoeb/services/chat/message_handlers/user_flow_handlers/generate.py
+++ b/byoeb-v1/byoeb/byoeb/services/chat/message_handlers/user_flow_handlers/generate.py
@@ -855,6 +855,7 @@ class ByoebUserGenerateResponse(Handler):
             cache_hit = False
 
             if embedding_fn and (FeatureFlag.CACHE_MESSAGES in feature_flags or message.user.test_user):
+                start_time = datetime.now(timezone.utc).timestamp()
                 embedding = await embedding_fn.aget_text_embedding(message_english)
                 end_time = datetime.now(timezone.utc).timestamp()
                 logger.debug("Generated cache embeddings in %ss", end_time - start_time)
@@ -894,7 +895,6 @@ class ByoebUserGenerateResponse(Handler):
                         if not utils.is_idk(response_en2):
                             skip_cache = False
                             response_en, response_source, tokens = response_en2, response_source2, tokens2
-                            expansion_success = True
                             break
 
                 if utils.is_idk(response_en) and (FeatureFlag.QUERY_DISAMBIGUATION in feature_flags or message.user.test_user):


### PR DESCRIPTION
# Summary
- Set all chat LLM clients to temperature=0.0 to remove randomness from both query rewriting and answer generation.
- Enforce deterministic ordering of retrieved chunks before building KB context, so identical requests see identical prompts and answers.
- Clean up debug prints in generate.py, replacing them with structured logging where still needed.

# Details
- LLM configuration (dependency_setup.py)
    - Updated llm_client and llm_translate_and_rewrite_client to explicitly use temperature=0.0 for:
    - Answer generation (final WhatsApp responses).
    - Translation + query rewriting (to keep query_en_addcontext stable across runs).

- Deterministic chunk ordering (generate.py)
    - After retrieval, chunks are collected into a dict and then sorted by chunk_id into sorted_chunks.
    - raw_kb_list and update_kb_list are now built from sorted_chunks instead of relying on non-deterministic dict iteration.
    - This ensures the KB context in the LLM prompt has a fixed order for the same retrieval result, eliminating subtle variation in emphasis.
    
- Logging cleanup (generate.py)
    - Removed noisy print()-based debug logging that was added during investigation.
    - Introduced a module-level logger (logger = logging.getLogger(__name__)) and converted remaining console-style prints (e.g. high-level “[GENERATE] …” flow messages) to structured logging calls with appropriate levels (debug, info, warning, exception).