### PR TITLE
Fix: Add missing json import in whatsapp.py

### DIFF
--- a/byoeb-v1/byoeb/byoeb/handler/user.py
+++ b/byoeb-v1/byoeb/byoeb/handler/user.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import byoeb.services.user.utils as user_utils
 from typing import List, Any, Dict
 from byoeb.services.user.user import UserService

--- a/byoeb-v1/byoeb/byoeb/services/channel/whatsapp.py
+++ b/byoeb-v1/byoeb/byoeb/services/channel/whatsapp.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import logging
 import byoeb.services.chat.constants as constants
 import byoeb.services.chat.utils as utils 


### PR DESCRIPTION
Fixes NameError issues in whatsapp.py and handler/user.py caused by missing imports.

Issue: Commit 83898b1 converted print statements to logger calls but forgot to add necessary imports in two files:
1. whatsapp.py - missing `import json` (used json.dumps())
2. handler/user.py - missing `import logging` (used logging.getLogger())

This caused test failures:
- test_update_users_endpoint
- test_onboarding_updates_users

Fix: Added missing imports to both files.

Files changed:
- byoeb/services/channel/whatsapp.py: Added `import json`
- byoeb/handler/user.py: Added `import logging`