### PR TITLE
Fix AttributeError: Use module-level logger instead of self._logger in query expansion

### DIFF
--- a/byoeb-v1/byoeb/byoeb/services/chat/message_handlers/user_flow_handlers/generate.py
+++ b/byoeb-v1/byoeb/byoeb/services/chat/message_handlers/user_flow_handlers/generate.py
@@ -700,11 +700,11 @@ class ByoebUserGenerateResponse(Handler):
 
         can_reformulate, result = parse_expansion_xml(response_text)
 
-        self._logger.debug("Original query: %s", original_query)
+        logger.debug("Original query: %s", original_query)
         if not can_reformulate:
-            self._logger.debug("Query expansion skipped: %s", original_query)
+            logger.debug("Query expansion skipped: %s", original_query)
             for reason in result or ["Insufficient context in original query"]:
-                self._logger.debug("Query expansion skip reason: %s", reason)
+                logger.debug("Query expansion skip reason: %s", reason)
             return []
 
         return result


### PR DESCRIPTION
## Problem
After the logging refactor (commit `83898b1b52a541e355efecc909fa51666f1e2508`), the `ByoebUserGenerateResponse` class was using `self._logger` in the `_expand_query` method, but the class doesn't initialize `_logger` in its `__init__` method. This caused an `AttributeError: 'ByoebUserGenerateResponse' object has no attribute '_logger'` when query expansion was attempted.

## Solution
Replaced `self._logger` with the module-level `logger` (defined at line 33) in three locations within the `_expand_query` method:
- Line 703: Original query logging
- Line 705: Query expansion skipped logging  
- Line 707: Query expansion skip reason logging

## Changes
- `byoeb/services/chat/message_handlers/user_flow_handlers/generate.py`
  - Changed `self._logger.debug(...)` → `logger.debug(...)` (3 instances)
