### PR TITLE
Add lint + import checks so missing-import/undefined-name fail before staging

### DIFF
--- a/.github/workflows/ci-cd-pipeline.yml
+++ b/.github/workflows/ci-cd-pipeline.yml
@@ -45,6 +45,31 @@ jobs:
       coverage-gist-id: ${{ github.event_name == 'push' && github.ref_name == 'a4i/main' && vars.COVERAGE_GIST_ID || '' }}
     secrets: inherit
 
+  # Lint: Ruff + import check (catches missing imports / undefined names before merge)
+  lint-byoeb-core:
+    name: lint (byoeb-core)
+    uses: ./.github/workflows/lint.yml
+    with:
+      directory: ./byoeb-v1/byoeb-core
+      package-import: byoeb_core
+    secrets: inherit
+
+  lint-byoeb:
+    name: lint (byoeb)
+    uses: ./.github/workflows/lint.yml
+    with:
+      directory: ./byoeb-v1/byoeb
+      package-import: byoeb
+    secrets: inherit
+
+  lint-byoeb-integrations:
+    name: lint (byoeb-integrations)
+    uses: ./.github/workflows/lint.yml
+    with:
+      directory: ./byoeb-v1/byoeb-integrations
+      package-import: byoeb_integrations
+    secrets: inherit
+
   # Step 2: Build (validates Dockerfile - uses Docker layer caching for fast builds)
   build:
     name: Build Docker image
@@ -96,7 +121,7 @@ jobs:
   # Step 4: Publish Docker Image (only if tests passed)
   publish-image:
     name: Publish image
-    needs: [build, unit-test-byoeb-core, unit-test-byoeb, unit-test-byoeb-integrations]
+    needs: [build, unit-test-byoeb-core, unit-test-byoeb, unit-test-byoeb-integrations, lint-byoeb-core, lint-byoeb, lint-byoeb-integrations]
     if: success() && github.event_name == 'push' && (github.ref_name == 'a4i/staging' || github.ref_name == 'a4i/main')
     runs-on: ubuntu-latest
     outputs:

--- a/byoeb-v1/byoeb-core/pyproject.toml
+++ b/byoeb-v1/byoeb-core/pyproject.toml
@@ -17,6 +17,7 @@ pytest = "^8.4.1"
 pytest-asyncio = "^1.1.0"
 pytest-cov = "^7.0.0"
 pytest-mock = "^3.15.0"
+ruff = "^0.8.0"
 
 [tool.pytest.ini_options]
 minversion = "8.0"
@@ -30,6 +31,18 @@ addopts = [
   "--cov-report=xml:coverage.xml"
 ]
 asyncio_mode = "auto"
+
+[tool.ruff]
+target-version = "py311"
+line-length = 120
+src = ["byoeb_core"]
+
+[tool.ruff.lint]
+select = ["E", "F", "B", "C4"]
+ignore = ["E501"]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = ["B011"]
 
 [build-system]
 requires = ["poetry-core"]

--- a/byoeb-v1/byoeb-integrations/pyproject.toml
+++ b/byoeb-v1/byoeb-integrations/pyproject.toml
@@ -27,6 +27,7 @@ pytest = "^8.3.3"
 coverage = {extras = ["toml"], version = "^7.10.5"}
 pytest-asyncio = "^1.1.0"
 pytest-cov = "^6.2.1"
+ruff = "^0.8.0"
 
 [tool.coverage.run]
 branch = true
@@ -43,6 +44,18 @@ omit = [
 
 [tool.pytest.ini_options]
 addopts = "--cov=byoeb_integrations --cov-branch --cov-report=term-missing:skip-covered --cov-report=xml:coverage.xml --cov-report=html"
+
+[tool.ruff]
+target-version = "py311"
+line-length = 120
+src = ["byoeb_integrations"]
+
+[tool.ruff.lint]
+select = ["E", "F", "B", "C4"]
+ignore = ["E501"]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = ["B011"]
 
 [build-system]
 requires = ["poetry-core"]

--- a/byoeb-v1/byoeb/pyproject.toml
+++ b/byoeb-v1/byoeb/pyproject.toml
@@ -32,6 +32,7 @@ pytest = "^8.4.1"
 pytest-asyncio = "^1.1.0"
 pytest-cov = "^7.0.0"
 pytest-mock = "^3.15.0"
+ruff = "^0.8.0"
 
 [build-system]
 requires = ["poetry-core"]
@@ -50,3 +51,20 @@ addopts = [
   "--cov-report=xml:coverage.xml"
 ]
 asyncio_mode = "auto"
+
+[tool.ruff]
+target-version = "py311"
+line-length = 120
+src = ["byoeb"]
+
+[tool.ruff.lint]
+select = [
+  "E",      # pycodestyle errors
+  "F",      # Pyflakes (F401 unused import, F821 undefined name)
+  "B",      # flake8-bugbear
+  "C4",     # flake8-comprehensions
+]
+ignore = ["E501"]  # line length handled by formatter if needed
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = ["B011"]  # assert False ok in tests


### PR DESCRIPTION
## Summary
Prevent missing-import and undefined-name (and similar) errors from reaching staging by running **Ruff** and an **import sanity check** in CI and optionally via pre-commit.

## Changes
- **Ruff** added as a dev dependency in all three Poetry projects (`byoeb`, `byoeb-core`, `byoeb-integrations`) with rules: E, F (Pyflakes), B, C4 — so we catch F821 (undefined name), F401 (unused import), and related issues.
- **Reusable workflow** `.github/workflows/lint.yml`: installs deps, runs `ruff check .`, then `python -c "import <package>"` per project.
- **CI** runs three lint jobs (one per project) in parallel with unit tests; **publish-image** now depends on lint passing so bad code cannot reach staging.
- **Pre-commit** (optional): `.pre-commit-config.yaml` runs Ruff per project on commit; see `docs/LINT_AND_IMPORT_CHECKS.md` for setup.

## Why
We’ve seen missing-import and attribute errors only surface on staging. Catching them in CI (and locally with pre-commit) keeps staging clean and blocks pushing this class of errors.

## How to verify
- Push branch and confirm the three “lint” jobs run and pass (or fail as expected if you introduce a typo/undefined name).
- Optionally: `pip install pre-commit && pre-commit install` and commit a change; Ruff should run on the changed project(s).