### PR TITLE
fix: auto-recover queue consumer from Session is closed and 504 Gateway Timeout errors

### DIFF
--- a/byoeb-v1/byoeb-integrations/byoeb_integrations/message_queue/azure/async_azure_storage_queue.py
+++ b/byoeb-v1/byoeb-integrations/byoeb_integrations/message_queue/azure/async_azure_storage_queue.py
@@ -113,6 +113,10 @@ class AsyncAzureStorageQueue(BaseQueue):
     ) -> Any:
         await self.__queue_client.delete_message(message)
     
+    @property
+    def is_closed(self) -> bool:
+        return self.__queue_client is None
+
     def get_azure_queue_client(self):
         return self.__queue_client
     

--- a/byoeb-v1/byoeb/byoeb/listener/message_consumer.py
+++ b/byoeb-v1/byoeb/byoeb/listener/message_consumer.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import asyncio
 from byoeb.application_logger.azure_app_insights import AppInsightsLogHandler
@@ -14,10 +15,40 @@ from byoeb.services.chat.message_consumer import MessageConsmerService
 from byoeb.services.databases.mongo_db import UserMongoDBService, MessageMongoDBService
 from byoeb_integrations.message_queue.azure.async_azure_storage_queue import AsyncAzureStorageQueue
 
+# Error signals that indicate a recoverable transport/session failure
+_TRANSIENT_ERROR_SIGNALS = (
+    "Session is closed",
+    "504",
+    "ServiceResponseError",
+    "Connection",
+    "timeout",
+    "TimeoutError",
+    "aiohttp",
+)
+_MAX_BACKOFF_SECONDS = 30
+
+
+def _match_messages_by_id(queue_messages: list, processed_ids: set) -> list:
+    """
+    Match raw queue messages against a set of processed message IDs.
+    Parses JSON content for an exact ID comparison; falls back to substring
+    search for any message whose content cannot be decoded.
+    """
+    matched = []
+    for msg in queue_messages:
+        try:
+            content = json.loads(msg.content)
+            msg_id = content.get("message_context", {}).get("message_id")
+            if msg_id in processed_ids:
+                matched.append(msg)
+        except (json.JSONDecodeError, AttributeError):
+            if any(pid in msg.content for pid in processed_ids):
+                matched.append(msg)
+    return matched
+
+
 class QueueConsumer:
 
-    _az_storage_queue: BaseQueue = None
-    _dlq_client: BaseQueue = None
     def __init__(
         self,
         account_url: str,
@@ -38,29 +69,29 @@ class QueueConsumer:
         self._channel_client_factory = channel_client_factory
         self._tracer = trace.get_tracer(__name__)
         self._batch_message_consumer_logger = AppInsightsLogHandler.getLogger("batch_message_consumer")
-    
+        # Instance-level (not class-level) so clients are never shared across instances
+        self._az_storage_queue: BaseQueue = None
+        self._dlq_client: BaseQueue = None
+        self._consecutive_errors = 0
+
     async def __create_azure_storage_queue_client(
         self,
         queue_name: str
     ) -> BaseQueue:
         """Create an Azure Storage Queue client with connection string or managed identity fallback."""
         from byoeb.chat_app.configuration.config import env_azure_storage_connection_string
-        
+
         if env_azure_storage_connection_string:
-            # Use connection string if available
             return await AsyncAzureStorageQueue.aget_or_create(
                 connection_string=env_azure_storage_connection_string,
                 queue_name=queue_name
             )
         else:
-            # Fallback to managed identity (for backward compatibility)
-            # Use DefaultAzureCredential - requires service account to be added in the cloud
-            # or explicit access via AZ CLI, so is very safe
             from azure.identity import DefaultAzureCredential
             if not self._account_url:
                 raise ValueError(
                     "Queue account URL must be set from AZURE_STORAGE_QUEUE_ACCOUNT_URL environment variable "
-                    "when connection string is not available. "
+                    "when connection string is not available."
                 )
             default_credential = DefaultAzureCredential()
             return await AsyncAzureStorageQueue.aget_or_create(
@@ -68,39 +99,60 @@ class QueueConsumer:
                 queue_name=queue_name,
                 credentials=default_credential
             )
-    
-    async def __get_or_create_dead_letter_queue_client(
-        self
-    ) -> BaseQueue:
-        # Environment variable is required (validated at startup in config.py)
+
+    async def __get_or_create_dead_letter_queue_client(self) -> BaseQueue:
         from byoeb.chat_app.configuration.config import env_azure_queue_dead_letter
         dlq_name = env_azure_queue_dead_letter
         self._dlq_client = await self.__create_azure_storage_queue_client(dlq_name)
         return self._dlq_client
-    
-    async def __get_or_create_az_storage_queue_client(
-        self,
-    ) -> BaseQueue:
-        if not self._az_storage_queue:
+
+    async def __get_or_create_az_storage_queue_client(self) -> BaseQueue:
+        # Also recreate if the underlying aiohttp session was closed
+        client_is_closed = (
+            isinstance(self._az_storage_queue, AsyncAzureStorageQueue)
+            and self._az_storage_queue.is_closed
+        )
+        if not self._az_storage_queue or client_is_closed:
             self._az_storage_queue = await self.__create_azure_storage_queue_client(self._queue_name)
         return self._az_storage_queue
-    
-    async def initialize(
-        self
-    ):
-        if self._az_storage_queue:
-            self._logger.info("Queue already initialized")
+
+    async def initialize(self):
+        if self._az_storage_queue and not (
+            isinstance(self._az_storage_queue, AsyncAzureStorageQueue)
+            and self._az_storage_queue.is_closed
+        ):
+            self._logger.info(f"[consumer] queue={self._queue_name} already initialized")
             return
         if self._consumer_type == "azure_storage_queue":
             self._az_storage_queue = await self.__get_or_create_az_storage_queue_client()
             if isinstance(self._az_storage_queue, AsyncAzureStorageQueue):
-                self._logger.info(f"Azure storage queue client created: {self._az_storage_queue}")
+                self._logger.info(f"[consumer] started for queue={self._queue_name}")
         else:
-            self._logger.error(f"Error initializing")
+            self._logger.error(f"[consumer] unknown consumer type: {self._consumer_type}")
 
-    async def __areceive(
-        self
-    ) -> list:
+    async def _safe_recreate_clients(self):
+        """Close and recreate all queue clients to recover from session / transport errors."""
+        for client in (self._az_storage_queue, self._dlq_client):
+            if isinstance(client, AsyncAzureStorageQueue):
+                try:
+                    await client._close()
+                except Exception:
+                    pass
+        self._az_storage_queue = None
+        self._dlq_client = None
+
+        await self.initialize()
+        await self.__get_or_create_dead_letter_queue_client()
+        self._logger.info(f"[consumer] recreated Azure queue clients for queue={self._queue_name}")
+
+    def _is_transient_error(self, e: Exception) -> bool:
+        error_str = str(e)
+        return any(signal in error_str for signal in _TRANSIENT_ERROR_SIGNALS)
+
+    def _backoff_seconds(self) -> float:
+        return min(2 ** self._consecutive_errors, _MAX_BACKOFF_SECONDS)
+
+    async def __areceive(self) -> list:
         messages = []
         if isinstance(self._az_storage_queue, AsyncAzureStorageQueue):
             msgs = await self._az_storage_queue.receive_message(
@@ -110,23 +162,14 @@ class QueueConsumer:
             )
             async for msg in msgs:
                 messages.append(msg)
-        
         return messages
 
-    async def __delete_message(
-        self,
-        messages: list,
-    ):
+    async def __delete_message(self, messages: list):
         if isinstance(self._az_storage_queue, AsyncAzureStorageQueue):
-            tasks = []
-            for message in messages:
-                task  = self._az_storage_queue.delete_message(message)
-                tasks.append(task)
+            tasks = [self._az_storage_queue.delete_message(message) for message in messages]
             await asyncio.gather(*tasks)
 
-    async def listen(
-        self
-    ):
+    async def listen(self):
         await self.initialize()
         message_consumer_svc = MessageConsmerService(
             config=self._config,
@@ -135,12 +178,13 @@ class QueueConsumer:
             channel_client_factory=self._channel_client_factory
         )
         queue_retry_count = self._config["app"]["queue_retry_count"]
-        dlq_client = await self.__get_or_create_dead_letter_queue_client()
-        self._logger.info(f"Queue info: {self._az_storage_queue}")
+        await self.__get_or_create_dead_letter_queue_client()
+        self._logger.info(f"[consumer] listening on queue={self._queue_name}")
 
         while True:
             with self._tracer.start_as_current_span("message_queue.batch_process", kind=trace.SpanKind.CONSUMER) as span:
                 try:
+                    self._logger.debug(f"[consumer] polling queue={self._queue_name}")
                     messages = await self.__areceive()
 
                     span.set_attribute("messaging.system", "azure_storage_queue")
@@ -150,15 +194,20 @@ class QueueConsumer:
 
                     if len(messages) == 0:
                         span.set_attribute("messaging.empty_batch", True)
+                        self._consecutive_errors = 0
                         await asyncio.sleep(0.5)
                         continue
+
+                    self._logger.info(f"[consumer] received {len(messages)} messages from queue={self._queue_name}")
+                    self._consecutive_errors = 0
 
                     message_content = []
                     dlq_count = 0
 
                     for message in messages:
                         if message.dequeue_count > queue_retry_count:
-                            await dlq_client.send_message(message.content)
+                            # Always use self._dlq_client so post-recovery calls use the fresh client
+                            await self._dlq_client.send_message(message.content)
                             await self.__delete_message([message])
                             dlq_count += 1
                             continue
@@ -172,32 +221,32 @@ class QueueConsumer:
 
                     with self._tracer.start_as_current_span("message_queue.consume_messages") as consume_span:
                         try:
-                            self._logger.info(f"Received {len(messages)} messages")
-
                             consume_span.set_attribute("messaging.batch_size", len(message_content))
 
                             successfully_processed_messages = await message_consumer_svc.consume(message_content) or []
-                            
-                            self._logger.info(f"consume() returned {len(successfully_processed_messages)} successfully processed messages")
 
-                            self._logger.info(f"Successfully processed {len(successfully_processed_messages)} messages")
+                            self._logger.info(
+                                f"[consumer] processed {len(successfully_processed_messages)}/{len(message_content)} "
+                                f"messages from queue={self._queue_name}"
+                            )
                             utils.log_to_text_file(f"Successfully processed {len(successfully_processed_messages)} messages")
 
                             consume_span.set_attribute("messaging.processed_count", len(successfully_processed_messages))
-                            consume_span.set_attribute("messaging.success_rate", 
-                                len(successfully_processed_messages) / len(message_content) if message_content else 0)
+                            consume_span.set_attribute(
+                                "messaging.success_rate",
+                                len(successfully_processed_messages) / len(message_content) if message_content else 0
+                            )
                             consume_span.set_status(Status(StatusCode.OK))
 
-                            processed_ids = {message.message_context.message_id for message in successfully_processed_messages}
-                            remove_messages = [msg for msg in messages if any(processed_id in msg.content for processed_id in processed_ids)]
-
+                            processed_ids = {m.message_context.message_id for m in successfully_processed_messages}
+                            remove_messages = _match_messages_by_id(messages, processed_ids)
                             await self.__delete_message(remove_messages)
-                            self._logger.info(f"Deleted {len(remove_messages)} messages")
+                            self._logger.info(f"[consumer] deleted {len(remove_messages)} messages")
 
                             consume_span.set_attribute("messaging.deleted_count", len(remove_messages))
 
                         except Exception as e:
-                            self._logger.error(f"Error consuming messages: {e}")
+                            self._logger.error(f"[consumer] error consuming messages: {e}")
                             consume_span.record_exception(e)
                             consume_span.set_status(Status(StatusCode.ERROR, str(e)))
                             successfully_processed_messages = []
@@ -209,35 +258,52 @@ class QueueConsumer:
                     span.set_attribute("messaging.success_count", len(successfully_processed_messages))
                     span.set_attribute("messaging.failure_count", len(messages) - len(successfully_processed_messages) - dlq_count)
 
-                    self._batch_message_consumer_logger.info(f"Processed batch of {len(messages)} messages for queue {self._queue_name} in {duration} seconds", extra={AppInsightsLogHandler.DETAILS: {
-                        "batch_id": str(uuid.uuid4()),
-                        "duration": duration,
-                        "message_count": len(messages),
-                        "success_count": len(successfully_processed_messages),
-                        "dlq_count": dlq_count,
-                        "queue_name": self._queue_name
-                    }})
-
+                    self._batch_message_consumer_logger.info(
+                        f"Processed batch of {len(messages)} messages for queue {self._queue_name} in {duration} seconds",
+                        extra={AppInsightsLogHandler.DETAILS: {
+                            "batch_id": str(uuid.uuid4()),
+                            "duration": duration,
+                            "message_count": len(messages),
+                            "success_count": len(successfully_processed_messages),
+                            "dlq_count": dlq_count,
+                            "queue_name": self._queue_name
+                        }}
+                    )
                     utils.log_to_text_file(f"Processed {len(messages)} message in: {duration} seconds")
 
                     span.set_status(Status(StatusCode.OK))
 
                 except Exception as e:
-                    self._logger.error(f"Error in batch processing: {e}")
+                    self._logger.error(f"[consumer] error in batch processing: {e}")
                     span.record_exception(e)
                     span.set_status(Status(StatusCode.ERROR, str(e)))
                     traceback.print_exc()
 
+                    self._consecutive_errors += 1
+                    if self._is_transient_error(e):
+                        backoff = self._backoff_seconds()
+                        self._logger.warning(
+                            f"[consumer] transient error on queue={self._queue_name} "
+                            f"(attempt #{self._consecutive_errors}), recreating clients "
+                            f"and backing off {backoff:.1f}s..."
+                        )
+                        try:
+                            await self._safe_recreate_clients()
+                        except Exception as recreate_err:
+                            self._logger.error(f"[consumer] failed to recreate clients: {recreate_err}")
+                        await asyncio.sleep(backoff)
+                        continue
+
                 await asyncio.sleep(0.5)
 
-    async def close(
-        self
-    ):
-        self._logger.info(self._az_storage_queue)
+    async def close(self):
+        self._logger.info(f"[consumer] closing for queue={self._queue_name}")
         if isinstance(self._az_storage_queue, AsyncAzureStorageQueue):
             await self._az_storage_queue._close()
+            self._az_storage_queue = None
         if isinstance(self._dlq_client, AsyncAzureStorageQueue):
             await self._dlq_client._close()
-            self._logger.info("Closed the Azure storage queue client")
+            self._dlq_client = None
+            self._logger.info(f"[consumer] closed Azure storage queue clients for queue={self._queue_name}")
         else:
-            self._logger.info("No queue client to close")
+            self._logger.info(f"[consumer] no queue client to close for queue={self._queue_name}")


### PR DESCRIPTION
## Problem

The Azure Storage Queue consumer was silently dying on transient network
errors (`RuntimeError: Session is closed`, `504 Gateway Timeout`).

The consumer loop kept running and logging errors, so it *looked* healthy,
but it was completely unable to receive messages. The queue would fill up
with no indication of the problem until messages expired.

This was first triggered in production after ~1 year of stable operation,
most likely by Azure Load Balancer's 4-minute idle TCP timeout firing when
the queue was empty for an extended period. The aiohttp session was killed
silently at the TCP level; the next `receive_messages()` call surfaced it
as `Session is closed`.

## Root causes

### 1. Class-level shared client (structural bug)
`_az_storage_queue` and `_dlq_client` were declared as class attributes.
If one `QueueConsumer` instance called `close()`, every other instance
holding the same Python object reference would use a dead session on the
next poll.

### 2. Zombie object reuse
After `_close()` runs, the `AsyncAzureStorageQueue` object still exists
(non-`None`) but its inner `QueueClient` is set to `None`. The
`if not self._az_storage_queue` guard did not detect this, so the "zombie"
object was handed back and crashed immediately.

### 3. No recovery logic
The outer `except` block only logged the error and slept 0.5 seconds, then
looped back with the same broken client — forever.

### 4. Stale DLQ local variable
`dlq_client` was captured once before the `while True` loop. After a
recovery cycle, `self._dlq_client` was a fresh client but `dlq_client`
still pointed to the old closed one.

## Changes

**`async_azure_storage_queue.py`**
- Add `is_closed` property — returns `True` when `__queue_client is None`
  (i.e. after `_close()` has run), giving callers a reliable way to detect
  a dead client without catching `AttributeError`

**`message_consumer.py`**
- Move `_az_storage_queue` and `_dlq_client` to `__init__` as instance
  attributes so clients are never shared across `QueueConsumer` instances
- Add `is_closed` guard in `__get_or_create_az_storage_queue_client()` so
  a zombie object is never reused
- Add `_safe_recreate_clients()` — atomically closes old clients and
  creates fresh ones with a new aiohttp session
- Add `_is_transient_error()` — matches `"Session is closed"`, `"504"`,
  `"ServiceResponseError"`, `"Connection"`, `"timeout"`, `"aiohttp"`
- Add exponential backoff (`min(2^N, 30)` seconds) on repeated transient
  errors so a flapping Azure endpoint does not get hammered
- Replace local `dlq_client` variable with `self._dlq_client` directly so
  DLQ sends after a recovery cycle use the fresh client
- Fix message deletion to parse JSON and compare the exact
  `message_context.message_id` field instead of substring-matching the raw
  content string (substring match could delete an unprocessed message if one
  ID appears inside another's JSON)
- Add `[consumer]` prefixed health logs on start, poll, receive, error,
  recreate, and close so it is immediately obvious from logs whether the
  consumer is alive

## Recovery behaviour after this fix

- ERROR [consumer] error in batch processing: Session is closed
- WARNING [consumer] transient error on queue=myqueue (attempt #1),
  recreating clients and backing off 2.0s...
- INFO [consumer] recreated Azure queue clients for queue=myqueue
- DEBUG [consumer] polling queue=myqueue ← back to normal


Backoff schedule: 2 s → 4 s → 8 s → 16 s → 30 s (capped).
Resets to 0 on any successful poll.

## Testing

- Verified error path: `"Session is closed" in str(e)` correctly matches
  the `RuntimeError` text from aiohttp
- Verified `is_closed` returns `True` after `_close()` sets
  `__queue_client = None`
- Verified `_safe_recreate_clients()` sets both references to `None`
  before calling `initialize()`, preventing double-create races

## References

- Azure Load Balancer idle timeout: 4 minutes (hard limit, not configurable
  per connection)
- aiohttp session lifecycle: session must be explicitly kept alive;
  idle TCP connections are killed transparently at the network layer