### PR TITLE
fix: prevent re-onboarding and welcome_messages_None.wav

### DIFF
--- a/byoeb-v1/byoeb/byoeb/services/chat/message_consumer.py
+++ b/byoeb-v1/byoeb/byoeb/services/chat/message_consumer.py
@@ -180,8 +180,14 @@ class MessageConsmerService:
             if (bot_message.message_category == constants.USER_TYPE
                 or bot_message.message_category == constants.LANGUAGE_SELECTION
                 or bot_message.message_category == constants.CONSENT):
-                self._logger.info("[__create_conversations] onboarding_flow msg_id=%s bot_cat=%s -> onboard", m.message_context.message_id, bot_message.message_category)
-                onboard_convs.append(conversation)
+                # Only route to onboarding if user still needs it (missing type or language)
+                if user.user_type is None or user.user_language is None:
+                    self._logger.info("[__create_conversations] onboarding_flow msg_id=%s bot_cat=%s -> onboard", m.message_context.message_id, bot_message.message_category)
+                    onboard_convs.append(conversation)
+                else:
+                    # Already onboarded user replying to old onboarding message -> regular flow
+                    self._logger.info("[__create_conversations] already_onboarded replying_to_onboarding -> conversations (msg_id=%s)", m.message_context.message_id)
+                    conversations.append(conversation)
             elif user.user_type is None or user.user_language is None:
                 # Check if this is an onboarding message from an already-registered user
                 is_onboarding_msg = utils.is_onboard(m.message_context.message_source_text, user.user_language)

--- a/byoeb-v1/byoeb/byoeb/services/user/onboarding.py
+++ b/byoeb-v1/byoeb/byoeb/services/user/onboarding.py
@@ -145,11 +145,13 @@ def create_consent_message(
 
 def create_audio(
     user_lang: str,
-    user_type: str
+    user_type: Optional[str]
 ):
     # Get the directory of the current script
     current_dir = os.path.dirname(os.path.abspath(__file__))
-    audio_path = os.path.join(current_dir, 'onboarding', user_lang, f'welcome_messages_{user_type}.wav')
+    # Fallback to asha when user_type is None (e.g. consent step before type persisted)
+    effective_type = user_type if user_type else UserType.ASHA.value
+    audio_path = os.path.join(current_dir, 'onboarding', user_lang, f'welcome_messages_{effective_type}.wav')
     audio_path = os.path.normpath(audio_path)
     audio_bytes = None
     with open(audio_path, 'rb') as file:
@@ -163,7 +165,10 @@ def create_initial_message(
     message: ByoebMessageContext
 ) -> ByoebMessageContext:
     mapped_user_type = map_user_type(message.user.user_type)
-    user_lang = message.user.user_language
+    # Fallback so create_audio never gets None (e.g. consent reply with stale user)
+    if mapped_user_type is None:
+        mapped_user_type = UserType.ASHA.value
+    user_lang = message.user.user_language or LanguageCode.HINDI.value
     audio_bytes, audio_type = create_audio(user_lang, mapped_user_type)
     text_message = THANK_YOU_DICT[mapped_user_type][user_lang]
     if mapped_user_type == UserType.ANM.value:

--- a/byoeb-v1/byoeb/tests/unit/services/test_message_consumer_proactive_return.py
+++ b/byoeb-v1/byoeb/tests/unit/services/test_message_consumer_proactive_return.py
@@ -2,9 +2,11 @@
 Unit tests for MessageConsmerService routing (byoeb.services.chat.message_consumer).
 
 These tests cover proactive return / onboarding routing: users with incomplete
-profile (user_type=None, user_language=None) or replying to an onboarding-step
-bot message (USER_TYPE / LANGUAGE_SELECTION / CONSENT) must be routed to
-onboarding (onboard_convs), not to the "already registered" flow (conversations).
+profile (user_type=None, user_language=None) go to onboarding (onboard_convs).
+Users who already have user_type and user_language set go to regular flow
+(conversations)—even when replying to an old onboarding-step message (USER_TYPE /
+LANGUAGE_SELECTION / CONSENT); that fix prevents already-onboarded users from
+seeing language selection again.
 
 Scenarios 1–3 from PR_PROACTIVE_RETURN_SCENARIO_VALIDATION.md. The existing
 test_onboarding.py in this package tests the onboarding flow module
@@ -200,13 +202,13 @@ def test_user_with_user_language_none_and_onboarding_message_with_user_id_goes_t
     asyncio.run(run())
 
 
-# ---------- Scenario 3: Reply to CONSENT / USER_TYPE / LANGUAGE_SELECTION -> onboarding ----------
+# ---------- Scenario 3: Complete user replying to onboarding-step -> regular flow (conversations) ----------
 
 
-def test_user_with_complete_info_replying_to_consent_goes_to_onboarding(
+def test_user_with_complete_info_replying_to_consent_goes_to_conversations(
     service, mock_user_db, mock_message_db
 ):
-    """Scenario 3: User has user_type and user_language set but replies to CONSENT bot message -> onboarding."""
+    """Scenario 3: User has user_type and user_language set and replies to CONSENT -> regular flow (conversations), not onboarding."""
     async def run():
         user = make_user(
             phone_number_id="919555555555", user_id="u5", user_type="asha", user_language="en"
@@ -219,15 +221,15 @@ def test_user_with_complete_info_replying_to_consent_goes_to_onboarding(
         )
         msg.user = user
         conversations, onboard_convs = await _create_conversations(service, [msg])
-        assert len(onboard_convs) == 1, "Reply to CONSENT step -> must go to onboarding"
-        assert len(conversations) == 0
+        assert len(conversations) == 1, "Already onboarded user replying to CONSENT -> regular flow"
+        assert len(onboard_convs) == 0
     asyncio.run(run())
 
 
-def test_user_with_complete_info_replying_to_user_type_goes_to_onboarding(
+def test_user_with_complete_info_replying_to_user_type_goes_to_conversations(
     service, mock_user_db, mock_message_db
 ):
-    """Scenario 3: User replies to USER_TYPE bot message -> onboarding."""
+    """Scenario 3: User has complete info and replies to USER_TYPE -> regular flow (conversations), not onboarding."""
     async def run():
         user = make_user(
             phone_number_id="919666666666", user_id="u6", user_type="asha", user_language="en"
@@ -238,15 +240,15 @@ def test_user_with_complete_info_replying_to_user_type_goes_to_onboarding(
         msg = make_message(user, message_source_text="Asha", message_id="m6", reply_id="bot-ut")
         msg.user = user
         conversations, onboard_convs = await _create_conversations(service, [msg])
-        assert len(onboard_convs) == 1
-        assert len(conversations) == 0
+        assert len(conversations) == 1
+        assert len(onboard_convs) == 0
     asyncio.run(run())
 
 
-def test_user_with_complete_info_replying_to_language_selection_goes_to_onboarding(
+def test_user_with_complete_info_replying_to_language_selection_goes_to_conversations(
     service, mock_user_db, mock_message_db
 ):
-    """Scenario 3: User replies to LANGUAGE_SELECTION bot message -> onboarding."""
+    """Scenario 3: User has complete info and replies to LANGUAGE_SELECTION -> regular flow (conversations), not onboarding."""
     async def run():
         user = make_user(
             phone_number_id="919777777777", user_id="u7", user_type="asha", user_language="en"
@@ -259,8 +261,8 @@ def test_user_with_complete_info_replying_to_language_selection_goes_to_onboardi
         msg = make_message(user, message_source_text="English", message_id="m7", reply_id="bot-lang")
         msg.user = user
         conversations, onboard_convs = await _create_conversations(service, [msg])
-        assert len(onboard_convs) == 1
-        assert len(conversations) == 0
+        assert len(conversations) == 1
+        assert len(onboard_convs) == 0
     asyncio.run(run())
 
 


### PR DESCRIPTION
## Summary
Fixes two onboarding issues: (1) already onboarded users receiving the language selection message again when replying to old onboarding messages, and (2) `FileNotFoundError` for `welcome_messages_None.wav` when `user_type` or `user_language` is `None`.

## Changes

### 1. Already onboarded users getting language selection again
- **Cause:** In `message_consumer.py`, any reply whose `reply_id` pointed to a bot message with category `USER_TYPE`, `LANGUAGE_SELECTION`, or `CONSENT` was always routed to onboarding, without checking if the user already had `user_type` and `user_language`.
- **Fix:** For those categories, only route to onboarding when the user still needs it (`user_type` or `user_language` is `None`). If both are set, route to the regular conversation flow and log `already_onboarded replying_to_onboarding -> conversations`.

### 2. `welcome_messages_None.wav` FileNotFoundError
- **Cause:** In `onboarding.py`, welcome audio path used `user_type` (and in one place `user_language`) directly; when they were `None` (e.g. consent step before type persisted or stale user), the path became `welcome_messages_None.wav`.
- **Fix:** Use safe defaults in `create_audio` and `create_initial_message`: if `user_type` is `None` use `UserType.ASHA.value`; if `user_language` is `None` use `LanguageCode.HINDI.value`, so the audio path is always valid.

## Files changed
- `byoeb/services/chat/message_consumer.py` – routing condition for onboarding vs regular flow
- `byoeb/services/user/onboarding.py` – defaults for `user_type` / `user_language` in welcome audio