### PR TITLE
message-consumer: improve concurrency by exploiting fire-and-forget

### DIFF
--- a/byoeb-v1/byoeb-integrations/byoeb_integrations/message_queue/azure/async_azure_storage_queue.py
+++ b/byoeb-v1/byoeb-integrations/byoeb_integrations/message_queue/azure/async_azure_storage_queue.py
@@ -1,8 +1,8 @@
-import asyncio
 import logging
 from enum import Enum
-from typing import Any
+from typing import Any, AsyncIterator
 from byoeb_core.message_queue.base import BaseQueue
+from azure.storage.queue import QueueMessage
 from azure.storage.queue.aio import QueueClient
 from azure.core.exceptions import ResourceExistsError
 
@@ -86,7 +86,7 @@ class AsyncAzureStorageQueue(BaseQueue):
     async def receive_message(
         self,
         **kwargs
-    ) -> Any:
+    ) -> AsyncIterator[QueueMessage]:
         visibility_timeout = kwargs.get(
             AzureStorageQueueParamsEnum.VISIBILITY_TIMEOUT.value,
             self.__VISIBILITY_TIMEOUT

--- a/byoeb-v1/byoeb/byoeb/chat_app/run.py
+++ b/byoeb-v1/byoeb/byoeb/chat_app/run.py
@@ -109,7 +109,6 @@ async def lifespan(app: FastAPI):
         from byoeb.chat_app.configuration.dependency_setup import start_scheduler, stop_scheduler
 
         try:
-            await message_consumer.initialize()
             asyncio.create_task(message_consumer.listen())
         except Exception as e:
             logger.error(f"Failed to initialize message consumer: {e}")

--- a/byoeb-v1/byoeb/byoeb/listener/message_consumer.py
+++ b/byoeb-v1/byoeb/byoeb/listener/message_consumer.py
@@ -26,7 +26,8 @@ class QueueConsumer:
         message_db_service: MessageMongoDBService,
         channel_client_factory: ChannelClientFactory,
         consuemr_type: str = None,
-        poll_frequency: float = 0.5
+        poll_frequency: float = 0.5,
+        concurrency: int = 16
     ):
         self._logger = logging.getLogger(__name__)
         self._consumer_type = consuemr_type
@@ -37,6 +38,7 @@ class QueueConsumer:
         self._batch_message_consumer_logger = AppInsightsLogHandler.getLogger("batch_message_consumer")
         self._message_consumer_svc = MessageConsmerService(config=self._config, user_db_service=user_db_service, message_db_service=message_db_service, channel_client_factory=channel_client_factory)
         self._poll_frequency = poll_frequency
+        self._concurrency = asyncio.Semaphore(concurrency)
         self._running = True
     
     async def __create_azure_storage_queue_client(
@@ -115,18 +117,21 @@ class QueueConsumer:
         queue_retry_count = self._config["app"]["queue_retry_count"]
         dlq_client = await self.__get_or_create_dead_letter_queue_client()
         self._logger.info(f"Queue info: {self._az_storage_queue}")
-        loop = asyncio.get_running_loop()
         while self._running:
+            await self.__heartbeat(dlq_client, queue_retry_count)
+            await asyncio.sleep(self._poll_frequency)
+
+    async def __heartbeat(self, dlq_client: BaseQueue, queue_retry_count: int):
+        async with self._concurrency:
             try:
                 batch = [message async for message in self.__areceive()]
             except Exception as e:
                 self._logger.exception(e)
                 traceback.print_exc()
-                continue
+                return
 
             if len(batch) == 0:
-                await asyncio.sleep(self._poll_frequency)
-                continue
+                return
 
             with self._tracer.start_as_current_span("message_queue.batch_process", kind=trace.SpanKind.CONSUMER, attributes={
                 "messaging.system": "azure_storage_queue",
@@ -136,6 +141,7 @@ class QueueConsumer:
             }) as span:
                 message_content = []
                 dlq_count = 0
+                loop = asyncio.get_running_loop()
                 for message in batch:
                     if message.dequeue_count > queue_retry_count:
                         # no need to spend consumer's time waiting on these tasks, can dispatch-and-forget
@@ -148,7 +154,6 @@ class QueueConsumer:
                 span.set_attribute("messaging.dlq_count", dlq_count)
                 if len(message_content) > 0:
                     loop.create_task(self.handle(message_content, dlq_count))
-            await asyncio.sleep(self._poll_frequency)
 
     async def handle(self, batch: list[QueueMessage], dlq_count: int):
         assert len(batch) > 0

--- a/byoeb-v1/byoeb/byoeb/listener/message_consumer.py
+++ b/byoeb-v1/byoeb/byoeb/listener/message_consumer.py
@@ -1,12 +1,12 @@
 import logging
 import asyncio
+from azure.storage.queue import QueueMessage
 from byoeb.application_logger.azure_app_insights import AppInsightsLogHandler
 import byoeb.utils.utils as utils
 import uuid
 import traceback
 from datetime import datetime
 from opentelemetry import trace
-from opentelemetry.trace import Status, StatusCode
 from byoeb_core.message_queue.base import BaseQueue
 from byoeb.factory import ChannelClientFactory
 from byoeb.services.chat.message_consumer import MessageConsmerService
@@ -25,18 +25,19 @@ class QueueConsumer:
         user_db_service: UserMongoDBService,
         message_db_service: MessageMongoDBService,
         channel_client_factory: ChannelClientFactory,
-        consuemr_type: str = None
+        consuemr_type: str = None,
+        poll_frequency: float = 0.5
     ):
         self._logger = logging.getLogger(__name__)
         self._consumer_type = consuemr_type
         self._account_url = account_url
         self._queue_name = queue_name
         self._config = config
-        self._user_db_service = user_db_service
-        self._message_db_service = message_db_service
-        self._channel_client_factory = channel_client_factory
         self._tracer = trace.get_tracer(__name__)
         self._batch_message_consumer_logger = AppInsightsLogHandler.getLogger("batch_message_consumer")
+        self._message_consumer_svc = MessageConsmerService(config=self._config, user_db_service=user_db_service, message_db_service=message_db_service, channel_client_factory=channel_client_factory)
+        self._poll_frequency = poll_frequency
+        self._running = True
     
     async def __create_azure_storage_queue_client(
         self,
@@ -109,120 +110,88 @@ class QueueConsumer:
             async for msg in msgs:
                 yield msg
 
-    async def __delete_message(
-        self,
-        messages: list,
-    ):
-        if isinstance(self._az_storage_queue, AsyncAzureStorageQueue):
-            tasks = []
-            for message in messages:
-                task  = self._az_storage_queue.delete_message(message)
-                tasks.append(task)
-            await asyncio.gather(*tasks)
-
-    async def listen(
-        self
-    ):
+    async def listen(self):
         await self.initialize()
-        message_consumer_svc = MessageConsmerService(
-            config=self._config,
-            user_db_service=self._user_db_service,
-            message_db_service=self._message_db_service,
-            channel_client_factory=self._channel_client_factory
-        )
         queue_retry_count = self._config["app"]["queue_retry_count"]
         dlq_client = await self.__get_or_create_dead_letter_queue_client()
         self._logger.info(f"Queue info: {self._az_storage_queue}")
-
-        while True:
+        loop = asyncio.get_running_loop()
+        while self._running:
             try:
-                messages = [m async for m in self.__areceive()]
-
-                if len(messages) == 0:
-                    await asyncio.sleep(0.5)
-                    continue
-
-                with self._tracer.start_as_current_span("message_queue.batch_process", kind=trace.SpanKind.CONSUMER) as span:
-                    span.set_attribute("messaging.system", "azure_storage_queue")
-                    span.set_attribute("messaging.destination", self._queue_name)
-                    span.set_attribute("messaging.destination_kind", "queue")
-                    span.set_attribute("messaging.message_count", len(messages))
-
-                    message_content = []
-                    dlq_count = 0
-
-                    for message in messages:
-                        if message.dequeue_count > queue_retry_count:
-                            await dlq_client.send_message(message.content)
-                            await self.__delete_message([message])
-                            dlq_count += 1
-                            continue
-                        message_content.append(message.content)
-
-                    if dlq_count > 0:
-                        span.set_attribute("messaging.dlq_count", dlq_count)
-
-                    start_time = datetime.now()
-                    successfully_processed_messages = []
-
-                    with self._tracer.start_as_current_span("message_queue.consume_messages") as consume_span:
-                        try:
-                            self._logger.info(f"Received {len(messages)} messages")
-
-                            consume_span.set_attribute("messaging.batch_size", len(message_content))
-
-                            successfully_processed_messages = await message_consumer_svc.consume(message_content) or []
-                            
-                            self._logger.info(f"consume() returned {len(successfully_processed_messages)} successfully processed messages")
-
-                            self._logger.info(f"Successfully processed {len(successfully_processed_messages)} messages")
-                            utils.log_to_text_file(f"Successfully processed {len(successfully_processed_messages)} messages")
-
-                            consume_span.set_attribute("messaging.processed_count", len(successfully_processed_messages))
-                            consume_span.set_attribute("messaging.success_rate", 
-                                len(successfully_processed_messages) / len(message_content) if message_content else 0)
-                            consume_span.set_status(Status(StatusCode.OK))
-
-                            processed_ids = {message.message_context.message_id for message in successfully_processed_messages}
-                            remove_messages = [msg for msg in messages if any(processed_id in msg.content for processed_id in processed_ids)]
-
-                            await self.__delete_message(remove_messages)
-                            self._logger.info(f"Deleted {len(remove_messages)} messages")
-
-                            consume_span.set_attribute("messaging.deleted_count", len(remove_messages))
-
-                        except Exception as e:
-                            self._logger.error(f"Error consuming messages: {e}")
-                            consume_span.record_exception(e)
-                            consume_span.set_status(Status(StatusCode.ERROR, str(e)))
-                            successfully_processed_messages = []
-
-                    end_time = datetime.now()
-                    duration = (end_time - start_time).total_seconds()
-
-                    span.set_attribute("messaging.duration_seconds", duration)
-                    span.set_attribute("messaging.success_count", len(successfully_processed_messages))
-                    span.set_attribute("messaging.failure_count", len(messages) - len(successfully_processed_messages) - dlq_count)
-
-                    self._batch_message_consumer_logger.info(f"Processed batch of {len(messages)} messages for queue {self._queue_name} in {duration} seconds", extra={AppInsightsLogHandler.DETAILS: {
-                        "batch_id": str(uuid.uuid4()),
-                        "duration": duration,
-                        "message_count": len(messages),
-                        "success_count": len(successfully_processed_messages),
-                        "dlq_count": dlq_count,
-                        "queue_name": self._queue_name
-                    }})
-
-                    utils.log_to_text_file(f"Processed {len(messages)} message in: {duration} seconds")
+                batch = [message async for message in self.__areceive()]
             except Exception as e:
+                self._logger.exception(e)
                 traceback.print_exc()
+                continue
 
-            await asyncio.sleep(0.5)
+            if len(batch) == 0:
+                await asyncio.sleep(self._poll_frequency)
+                continue
+
+            with self._tracer.start_as_current_span("message_queue.batch_process", kind=trace.SpanKind.CONSUMER, attributes={
+                "messaging.system": "azure_storage_queue",
+                "messaging.destination": self._queue_name,
+                "messaging.destination_kind": "queue",
+                "messaging.message_count": len(batch)
+            }) as span:
+                message_content = []
+                dlq_count = 0
+                for message in batch:
+                    if message.dequeue_count > queue_retry_count:
+                        # no need to spend consumer's time waiting on these tasks, can dispatch-and-forget
+                        loop.create_task(dlq_client.send_message(message.content))
+                        loop.create_task(self._az_storage_queue.delete_message(message))
+                        dlq_count += 1
+                        continue
+                    message_content.append(message)
+
+                span.set_attribute("messaging.dlq_count", dlq_count)
+                if len(message_content) > 0:
+                    loop.create_task(self.handle(message_content, dlq_count))
+            await asyncio.sleep(self._poll_frequency)
+
+    async def handle(self, batch: list[QueueMessage], dlq_count: int):
+        assert len(batch) > 0
+        self._logger.info(f"Received {len(batch)} messages")
+
+        start_time = datetime.now()
+        successfully_processed_messages = []
+        with self._tracer.start_as_current_span("message_queue.consume_messages", attributes={"messaging.batch_size": len(batch)}) as span:
+            successfully_processed_messages = await self._message_consumer_svc.consume([m.content for m in batch]) or []
+            span.set_attribute("messaging.processed_count", len(successfully_processed_messages))
+            span.set_attribute("messaging.success_rate", len(successfully_processed_messages) / len(batch))
+
+            self._logger.info(f"consume() returned {len(successfully_processed_messages)} successfully processed messages")
+            self._logger.info(f"Successfully processed {len(successfully_processed_messages)} messages")
+            utils.log_to_text_file(f"Successfully processed {len(successfully_processed_messages)} messages")
+
+            processed_ids = {message.message_context.message_id for message in successfully_processed_messages}
+            remove_messages = [msg for msg in batch if any(processed_id in msg.content for processed_id in processed_ids)]
+
+            await asyncio.gather(*[self._az_storage_queue.delete_message(m) for m in remove_messages])
+            self._logger.info(f"Deleted {len(remove_messages)} messages")
+
+            span.set_attribute("messaging.deleted_count", len(remove_messages))
+            end_time = datetime.now()
+            duration = (end_time - start_time).total_seconds()
+            span.set_attribute("messaging.duration_seconds", duration)
+            span.set_attribute("messaging.success_count", len(successfully_processed_messages))
+            span.set_attribute("messaging.failure_count", len(batch) - len(successfully_processed_messages) - dlq_count)
+
+        self._batch_message_consumer_logger.info(f"Processed batch of {len(batch)} messages for queue {self._queue_name} in {duration} seconds", extra={AppInsightsLogHandler.DETAILS: {
+            "batch_id": str(uuid.uuid4()),
+            "duration": duration,
+            "message_count": len(batch),
+            "success_count": len(successfully_processed_messages),
+            "dlq_count": dlq_count,
+            "queue_name": self._queue_name
+        }})
+        utils.log_to_text_file(f"Processed {len(batch)} message in: {duration} seconds")
 
     async def close(
         self
     ):
-        self._logger.info(self._az_storage_queue)
+        self._running = False
         if isinstance(self._az_storage_queue, AsyncAzureStorageQueue):
             await self._az_storage_queue._close()
         if isinstance(self._dlq_client, AsyncAzureStorageQueue):

--- a/byoeb-v1/byoeb/byoeb/listener/message_consumer.py
+++ b/byoeb-v1/byoeb/byoeb/listener/message_consumer.py
@@ -4,7 +4,6 @@ from byoeb.application_logger.azure_app_insights import AppInsightsLogHandler
 import byoeb.utils.utils as utils
 import uuid
 import traceback
-import time
 from datetime import datetime
 from opentelemetry import trace
 from opentelemetry.trace import Status, StatusCode
@@ -100,8 +99,7 @@ class QueueConsumer:
 
     async def __areceive(
         self
-    ) -> list:
-        messages = []
+    ):
         if isinstance(self._az_storage_queue, AsyncAzureStorageQueue):
             msgs = await self._az_storage_queue.receive_message(
                 visibility_timeout=self._config["message_queue"]["azure"]["visibility_timeout"],
@@ -109,9 +107,7 @@ class QueueConsumer:
                 max_messages=self._config["app"]["batch_size"]
             )
             async for msg in msgs:
-                messages.append(msg)
-        
-        return messages
+                yield msg
 
     async def __delete_message(
         self,
@@ -140,7 +136,7 @@ class QueueConsumer:
 
         while True:
             try:
-                messages = await self.__areceive()
+                messages = [m async for m in self.__areceive()]
 
                 if len(messages) == 0:
                     await asyncio.sleep(0.5)

--- a/byoeb-v1/byoeb/byoeb/listener/message_consumer.py
+++ b/byoeb-v1/byoeb/byoeb/listener/message_consumer.py
@@ -139,19 +139,18 @@ class QueueConsumer:
         self._logger.info(f"Queue info: {self._az_storage_queue}")
 
         while True:
-            with self._tracer.start_as_current_span("message_queue.batch_process", kind=trace.SpanKind.CONSUMER) as span:
-                try:
-                    messages = await self.__areceive()
+            try:
+                messages = await self.__areceive()
 
+                if len(messages) == 0:
+                    await asyncio.sleep(0.5)
+                    continue
+
+                with self._tracer.start_as_current_span("message_queue.batch_process", kind=trace.SpanKind.CONSUMER) as span:
                     span.set_attribute("messaging.system", "azure_storage_queue")
                     span.set_attribute("messaging.destination", self._queue_name)
                     span.set_attribute("messaging.destination_kind", "queue")
                     span.set_attribute("messaging.message_count", len(messages))
-
-                    if len(messages) == 0:
-                        span.set_attribute("messaging.empty_batch", True)
-                        await asyncio.sleep(0.5)
-                        continue
 
                     message_content = []
                     dlq_count = 0
@@ -219,16 +218,10 @@ class QueueConsumer:
                     }})
 
                     utils.log_to_text_file(f"Processed {len(messages)} message in: {duration} seconds")
+            except Exception as e:
+                traceback.print_exc()
 
-                    span.set_status(Status(StatusCode.OK))
-
-                except Exception as e:
-                    self._logger.error(f"Error in batch processing: {e}")
-                    span.record_exception(e)
-                    span.set_status(Status(StatusCode.ERROR, str(e)))
-                    traceback.print_exc()
-
-                await asyncio.sleep(0.5)
+            await asyncio.sleep(0.5)
 
     async def close(
         self

--- a/byoeb-v1/byoeb/byoeb/listener/message_consumer.py
+++ b/byoeb-v1/byoeb/byoeb/listener/message_consumer.py
@@ -4,7 +4,6 @@ from azure.storage.queue import QueueMessage
 from byoeb.application_logger.azure_app_insights import AppInsightsLogHandler
 import byoeb.utils.utils as utils
 import uuid
-import traceback
 from datetime import datetime
 from opentelemetry import trace
 from byoeb_core.message_queue.base import BaseQueue
@@ -117,71 +116,63 @@ class QueueConsumer:
         queue_retry_count = self._config["app"]["queue_retry_count"]
         dlq_client = await self.__get_or_create_dead_letter_queue_client()
         self._logger.info(f"Queue info: {self._az_storage_queue}")
+        loop = asyncio.get_running_loop()
         while self._running:
-            await self.__heartbeat(dlq_client, queue_retry_count)
+            # using same semaphore here as in handle() - this is intended. when we are at full queue
+            # capacity, there is no point querying the queue for messages only to hold messages in memory.
+            async with self._concurrency:
+                try:
+                    batch = [message async for message in self.__areceive()]
+                except Exception as e:
+                    batch = []
+                    self._logger.exception(e)
+
+            messages = []
+            dlq_count = 0
+            for message in batch:
+                if message.dequeue_count > queue_retry_count:
+                    # no need to spend consumer's time waiting on these tasks, can dispatch-and-forget
+                    loop.create_task(dlq_client.send_message(message.content))
+                    loop.create_task(self._az_storage_queue.delete_message(message))
+                    dlq_count += 1
+                    continue
+                messages.append(message)
+
+            if len(messages) > 0:
+                loop.create_task(self.handle(messages, dlq_count))
+
             await asyncio.sleep(self._poll_frequency)
 
-    async def __heartbeat(self, dlq_client: BaseQueue, queue_retry_count: int):
+    async def handle(self, batch: list[QueueMessage], dlq_count: int):
         async with self._concurrency:
-            try:
-                batch = [message async for message in self.__areceive()]
-            except Exception as e:
-                self._logger.exception(e)
-                traceback.print_exc()
-                return
-
-            if len(batch) == 0:
-                return
-
-            with self._tracer.start_as_current_span("message_queue.batch_process", kind=trace.SpanKind.CONSUMER, attributes={
+            self._logger.info(f"Received {len(batch)} messages")
+            with self._tracer.start_as_current_span("message_queue.consume_messages", attributes={
                 "messaging.system": "azure_storage_queue",
                 "messaging.destination": self._queue_name,
                 "messaging.destination_kind": "queue",
-                "messaging.message_count": len(batch)
+                "messaging.message_count": len(batch),
+                "messaging.dlq_count": dlq_count
             }) as span:
-                message_content = []
-                dlq_count = 0
-                loop = asyncio.get_running_loop()
-                for message in batch:
-                    if message.dequeue_count > queue_retry_count:
-                        # no need to spend consumer's time waiting on these tasks, can dispatch-and-forget
-                        loop.create_task(dlq_client.send_message(message.content))
-                        loop.create_task(self._az_storage_queue.delete_message(message))
-                        dlq_count += 1
-                        continue
-                    message_content.append(message)
+                start_time = datetime.now()
+                successfully_processed_messages = await self._message_consumer_svc.consume([m.content for m in batch]) or []
+                end_time = datetime.now()
+                duration = (end_time - start_time).total_seconds()
 
-                span.set_attribute("messaging.dlq_count", dlq_count)
-                if len(message_content) > 0:
-                    loop.create_task(self.handle(message_content, dlq_count))
+                span.set_attribute("messaging.duration_seconds", duration)
+                span.set_attribute("messaging.success_count", len(successfully_processed_messages))
+                span.set_attribute("messaging.failure_count", len(batch) - len(successfully_processed_messages) - dlq_count)
+                span.set_attribute("messaging.processed_count", len(successfully_processed_messages))
+                span.set_attribute("messaging.success_rate", len(successfully_processed_messages) / len(batch))
 
-    async def handle(self, batch: list[QueueMessage], dlq_count: int):
-        assert len(batch) > 0
-        self._logger.info(f"Received {len(batch)} messages")
+                self._logger.info(f"Successfully processed {len(successfully_processed_messages)} messages")
+                utils.log_to_text_file(f"Successfully processed {len(successfully_processed_messages)} messages")
 
-        start_time = datetime.now()
-        successfully_processed_messages = []
-        with self._tracer.start_as_current_span("message_queue.consume_messages", attributes={"messaging.batch_size": len(batch)}) as span:
-            successfully_processed_messages = await self._message_consumer_svc.consume([m.content for m in batch]) or []
-            span.set_attribute("messaging.processed_count", len(successfully_processed_messages))
-            span.set_attribute("messaging.success_rate", len(successfully_processed_messages) / len(batch))
+                processed_ids = {message.message_context.message_id for message in successfully_processed_messages}
+                remove_messages = [msg for msg in batch if any(processed_id in msg.content for processed_id in processed_ids)]
 
-            self._logger.info(f"consume() returned {len(successfully_processed_messages)} successfully processed messages")
-            self._logger.info(f"Successfully processed {len(successfully_processed_messages)} messages")
-            utils.log_to_text_file(f"Successfully processed {len(successfully_processed_messages)} messages")
-
-            processed_ids = {message.message_context.message_id for message in successfully_processed_messages}
-            remove_messages = [msg for msg in batch if any(processed_id in msg.content for processed_id in processed_ids)]
-
-            await asyncio.gather(*[self._az_storage_queue.delete_message(m) for m in remove_messages])
-            self._logger.info(f"Deleted {len(remove_messages)} messages")
-
-            span.set_attribute("messaging.deleted_count", len(remove_messages))
-            end_time = datetime.now()
-            duration = (end_time - start_time).total_seconds()
-            span.set_attribute("messaging.duration_seconds", duration)
-            span.set_attribute("messaging.success_count", len(successfully_processed_messages))
-            span.set_attribute("messaging.failure_count", len(batch) - len(successfully_processed_messages) - dlq_count)
+                await asyncio.gather(*[self._az_storage_queue.delete_message(m) for m in remove_messages])
+                self._logger.info(f"Deleted {len(remove_messages)} messages")
+                span.set_attribute("messaging.deleted_count", len(remove_messages))
 
         self._batch_message_consumer_logger.info(f"Processed batch of {len(batch)} messages for queue {self._queue_name} in {duration} seconds", extra={AppInsightsLogHandler.DETAILS: {
             "batch_id": str(uuid.uuid4()),


### PR DESCRIPTION
## Introduction
ASHABot suffers from a concurrency issue at the very root of message flow (queue consumer). Although the downstream is entirely concurrency-aware, the consumer immensely throttles response times in real life scenario.

## Problem
Azure Storage Queues require polling rather than push-based delivery. Current config polls up to 5 messages every 0.5s, then blocks until all are processed before polling again. 1 slow message stalls the consumer just as much as 5.

Under low load this is fine. But under higher load, a single slow message can hold the consumer long enough that a full batch of 5 accumulates by the next poll, which can more or less work favorably, but also amount to a delay of, say, 10+ seconds (i.e., avg. ASHABot response time).

Under heavy load, your message is likely waiting in the queue longer than it takes to actually process your message.

## Approach
Polling and processing are decoupled. Previously `listen()` awaited processing before polling again so one slow message blocked everything. Now each poll dispatches `handle()` as a fire-and-forget task so consumer keeps polling on schedule regardless of how long processing takes.

Fire-and-forget ofcourse has its share of disadvantages here, but the approach has been designed to address its flaws:
- In terms of observability, this area is more or less kept unchanged. OTEL spans + console traces should sufficiently prevent any errors from being silently tossed away.
- In terms of unexpected and excess load - a semaphore caps how many messages can be in a processing state (16) to prevent unbounded task spawning under load. 16 is far too generous, however our concern is not CPU consumption here but rather a mechanism to shield ASHABot from API rate limits downstream (whatsapp, chat-completion).