### PR TITLE
fix: Only show language selection for onboarding-like messages; add telemetry for transients

### DIFF
--- a/byoeb-v1/byoeb/byoeb/constants/onboarding_text.py
+++ b/byoeb-v1/byoeb/byoeb/constants/onboarding_text.py
@@ -103,63 +103,54 @@ THANK_YOU_DICT = {
     # Note: OTHERS user type uses ASHA messages (fallback handled in code)
 }
 
-# Phrases that indicate user wants to register (onboarding intent). Used by is_onboard() and the
-# language-selection guard. Includes ASHA, ANM, and Others user-type variants.
-ONBOARD_WELCOME_MESSAGE_DICT = {
+# Common onboarding phrases accepted in all languages (ASHA, ANM, Others variants).
+# Used together with language-specific phrases to avoid duplication.
+ONBOARD_GLOBAL_PHRASES = [
+    "onboard asha",
+    "onboard-asha",
+    "onboard anm",
+    "onboard-anm",
+    "onboard others",
+    "onboard-others",
+]
+
+# Language-specific onboarding phrases only (no English "onboard *" here; those are in ONBOARD_GLOBAL_PHRASES).
+ONBOARD_LANGUAGE_SPECIFIC_PHRASES = {
     LanguageCode.HINDI.value: [
         "में एक आशा हूँ और मुझे आशा सहेली बोट से जुड़ना है",
         "मैं आशा हूँ और मुझे आशा सहेली बोट से जुड़ना है",
         "आशा सहेली बोट से जुड़ना है",
         "आशा सहेली से जुड़ना है",
-        "onboard asha",
-        "onboard-asha",
-        "onboard anm",
-        "onboard-anm",
-        "onboard others",
-        "onboard-others",
     ],
     LanguageCode.ENGLISH.value: [
-        "onboard asha",
-        "onboard-asha",
         "ONBOARD ASHA",
-        "onboard anm",
-        "onboard-anm",
         "ONBOARD ANM",
-        "onboard others",
-        "onboard-others",
         "ONBOARD OTHERS",
     ],
     LanguageCode.MARATHI.value: [
         "मी आशा आहे आणि मला आशा सहेली बॉटमध्ये सामील व्हायचे आहे",
-        "मी आशा आहे आणि मला आशा सहेली बॉटमध्ये सामील व्हायचे आहे",
         "आशा सहेली बॉटमध्ये सामील व्हायचे आहे",
         "आशा सहेली बॉटमध्ये सामील",
         "आशा सहेली सामील व्हायचे आहे",
-        "onboard asha",
-        "onboard-asha",
-        "onboard anm",
-        "onboard-anm",
-        "onboard others",
-        "onboard-others",
     ],
     LanguageCode.TELUGU.value: [
-        "నేను ఆశాను మరియు ఆశా సహేలి బాట్‌లో చేరాలనుకుంటున్నాను",
         "నేను ఆశాను మరియు ఆశా సహేలి బాట్‌లో చేరాలనుకుంటున్నాను",
         "ఆశా సహేలి బాట్‌లో చేరాలనుకుంటున్నాను",
         "ఆశా సహేలి బాట్‌లో చేరాలి",
         "ఆశా సహేలి చేరాలనుకుంటున్నాను",
-        "onboard asha",
-        "onboard-asha",
-        "onboard anm",
-        "onboard-anm",
-        "onboard others",
-        "onboard-others",
     ],
 }
 
-# Shown when user is in onboarding path but message is not onboarding-like (e.g. not "onboard asha").
+# Phrases that indicate user wants to register (onboarding intent). Used by is_onboard() and the
+# language-selection guard. Each language: language-specific phrases + global phrases.
+ONBOARD_WELCOME_MESSAGE_DICT = {
+    lang: ONBOARD_LANGUAGE_SPECIFIC_PHRASES[lang] + ONBOARD_GLOBAL_PHRASES
+    for lang in ONBOARD_LANGUAGE_SPECIFIC_PHRASES
+}
+
+# Shown when user is in onboarding path but message is not onboarding-like. Role is not yet known.
 REGISTER_PROMPT_TEXT = (
-    "To register with ASHA Saheli, please send 'onboard asha' or a similar phrase in your language."
+    "To register with ASHA Saheli, please send 'onboard asha', 'onboard anm', or 'onboard others'."
 )
 
 # Suggested questions list text + items

--- a/byoeb-v1/byoeb/byoeb/constants/onboarding_text.py
+++ b/byoeb-v1/byoeb/byoeb/constants/onboarding_text.py
@@ -103,24 +103,44 @@ THANK_YOU_DICT = {
     # Note: OTHERS user type uses ASHA messages (fallback handled in code)
 }
 
+# Phrases that indicate user wants to register (onboarding intent). Used by is_onboard() and the
+# language-selection guard. Includes ASHA, ANM, and Others user-type variants.
 ONBOARD_WELCOME_MESSAGE_DICT = {
     LanguageCode.HINDI.value: [
         "में एक आशा हूँ और मुझे आशा सहेली बोट से जुड़ना है",
         "मैं आशा हूँ और मुझे आशा सहेली बोट से जुड़ना है",
         "आशा सहेली बोट से जुड़ना है",
         "आशा सहेली से जुड़ना है",
-        "onboard asha",  # Also accept English "onboard asha" for Hindi users
-        "onboard-asha"
+        "onboard asha",
+        "onboard-asha",
+        "onboard anm",
+        "onboard-anm",
+        "onboard others",
+        "onboard-others",
     ],
-    LanguageCode.ENGLISH.value: ["onboard asha", "onboard-asha", "ONBOARD ASHA"],
+    LanguageCode.ENGLISH.value: [
+        "onboard asha",
+        "onboard-asha",
+        "ONBOARD ASHA",
+        "onboard anm",
+        "onboard-anm",
+        "ONBOARD ANM",
+        "onboard others",
+        "onboard-others",
+        "ONBOARD OTHERS",
+    ],
     LanguageCode.MARATHI.value: [
         "मी आशा आहे आणि मला आशा सहेली बॉटमध्ये सामील व्हायचे आहे",
         "मी आशा आहे आणि मला आशा सहेली बॉटमध्ये सामील व्हायचे आहे",
         "आशा सहेली बॉटमध्ये सामील व्हायचे आहे",
         "आशा सहेली बॉटमध्ये सामील",
         "आशा सहेली सामील व्हायचे आहे",
-        "onboard asha",  # Also accept English for Marathi users
-        "onboard-asha"
+        "onboard asha",
+        "onboard-asha",
+        "onboard anm",
+        "onboard-anm",
+        "onboard others",
+        "onboard-others",
     ],
     LanguageCode.TELUGU.value: [
         "నేను ఆశాను మరియు ఆశా సహేలి బాట్‌లో చేరాలనుకుంటున్నాను",
@@ -128,8 +148,12 @@ ONBOARD_WELCOME_MESSAGE_DICT = {
         "ఆశా సహేలి బాట్‌లో చేరాలనుకుంటున్నాను",
         "ఆశా సహేలి బాట్‌లో చేరాలి",
         "ఆశా సహేలి చేరాలనుకుంటున్నాను",
-        "onboard asha",  # Also accept English for Telugu users
-        "onboard-asha"
+        "onboard asha",
+        "onboard-asha",
+        "onboard anm",
+        "onboard-anm",
+        "onboard others",
+        "onboard-others",
     ],
 }
 

--- a/byoeb-v1/byoeb/byoeb/constants/onboarding_text.py
+++ b/byoeb-v1/byoeb/byoeb/constants/onboarding_text.py
@@ -157,6 +157,11 @@ ONBOARD_WELCOME_MESSAGE_DICT = {
     ],
 }
 
+# Shown when user is in onboarding path but message is not onboarding-like (e.g. not "onboard asha").
+REGISTER_PROMPT_TEXT = (
+    "To register with ASHA Saheli, please send 'onboard asha' or a similar phrase in your language."
+)
+
 # Suggested questions list text + items
 RELATED_QUESTIONS = {
     "description": {

--- a/byoeb-v1/byoeb/byoeb/services/chat/constants.py
+++ b/byoeb-v1/byoeb/byoeb/services/chat/constants.py
@@ -61,5 +61,6 @@ USER_DB_QUERIES = "user_db_queries"
 
 USER_TYPE = "user_type"
 LANGUAGE_SELECTION = "language_selection"
+REGISTER_PROMPT = "register_prompt"
 CONSENT = "consent"
 THANK_YOU = "thank_you"

--- a/byoeb-v1/byoeb/byoeb/services/chat/message_consumer.py
+++ b/byoeb-v1/byoeb/byoeb/services/chat/message_consumer.py
@@ -98,24 +98,14 @@ class MessageConsmerService:
         user_ids = list(set([hashlib.md5(number.encode()).hexdigest() for number in phone_numbers]))
         self._logger.debug("[__create_conversations] phone_numbers=%s user_ids_count=%s", phone_numbers, len(user_ids))
 
-        byoeb_users = await self._user_db_service.get_users(user_ids)
+        try:
+            byoeb_users = await self._user_db_service.get_users(user_ids)
+        except Exception as e:
+            self._logger.exception(
+                "[__create_conversations] user lookup failed (database/network error): %s", e
+            )
+            raise
         self._logger.debug("[__create_conversations] fetched_users=%s", len(byoeb_users))
-
-        # Telemetry: detect possible DB/network transient when fewer users returned than requested
-        if len(byoeb_users) < len(user_ids):
-            try:
-                AppInsightsLogHandler.getLogger("onboarding_routing").warning(
-                    "user_lookup_returned_fewer_than_requested (possible transient)",
-                    extra={
-                        AppInsightsLogHandler.DETAILS: {
-                            "requested_count": len(user_ids),
-                            "fetched_count": len(byoeb_users),
-                            "missing_count": len(user_ids) - len(byoeb_users),
-                        }
-                    },
-                )
-            except Exception as e:
-                self._logger.warning("[onboarding_routing] telemetry failed: %s", e)
 
         for m in messages:
             user = self.__get_user(byoeb_users, m.user.phone_number_id)

--- a/byoeb-v1/byoeb/byoeb/services/chat/message_consumer.py
+++ b/byoeb-v1/byoeb/byoeb/services/chat/message_consumer.py
@@ -223,6 +223,7 @@ class MessageConsmerService:
 
             if (bot_message.message_category == constants.USER_TYPE
                 or bot_message.message_category == constants.LANGUAGE_SELECTION
+                or bot_message.message_category == constants.REGISTER_PROMPT
                 or bot_message.message_category == constants.CONSENT):
                 self._logger.info("[__create_conversations] onboarding_flow msg_id=%s bot_cat=%s -> onboard", m.message_context.message_id, bot_message.message_category)
                 onboard_convs.append(conversation)

--- a/byoeb-v1/byoeb/byoeb/services/chat/message_consumer.py
+++ b/byoeb-v1/byoeb/byoeb/services/chat/message_consumer.py
@@ -101,10 +101,33 @@ class MessageConsmerService:
         byoeb_users = await self._user_db_service.get_users(user_ids)
         self._logger.debug("[__create_conversations] fetched_users=%s", len(byoeb_users))
 
+        # Telemetry: detect possible DB/network transient when fewer users returned than requested
+        if len(byoeb_users) < len(user_ids):
+            AppInsightsLogHandler.getLogger("onboarding_routing").warning(
+                "user_lookup_returned_fewer_than_requested (possible transient)",
+                extra={
+                    AppInsightsLogHandler.DETAILS: {
+                        "requested_count": len(user_ids),
+                        "fetched_count": len(byoeb_users),
+                        "missing_count": len(user_ids) - len(byoeb_users),
+                    }
+                },
+            )
+
         for m in messages:
             user = self.__get_user(byoeb_users, m.user.phone_number_id)
             if user is None:
                 self._logger.info("[__create_conversations] user_not_found phone=%s -> onboard", m.user.phone_number_id)
+                AppInsightsLogHandler.getLogger("onboarding_routing").info(
+                    "routed_to_onboard: user_not_found",
+                    extra={
+                        AppInsightsLogHandler.DETAILS: {
+                            "reason": "user_not_found",
+                            "message_id": m.message_context.message_id,
+                            "phone_number_id": m.user.phone_number_id,
+                        }
+                    },
+                )
                 onboard_convs.append(m)
                 continue
 
@@ -162,6 +185,18 @@ class MessageConsmerService:
                     else:
                         # New user needs onboarding
                         self._logger.info("[__create_conversations] no_bot_msg + needs_onboarding -> onboard (msg_id=%s)", m.message_context.message_id)
+                        AppInsightsLogHandler.getLogger("onboarding_routing").info(
+                            "routed_to_onboard: needs_onboarding_no_bot_msg",
+                            extra={
+                                AppInsightsLogHandler.DETAILS: {
+                                    "reason": "needs_onboarding_no_bot_msg",
+                                    "message_id": m.message_context.message_id,
+                                    "phone_number_id": m.user.phone_number_id,
+                                    "has_user_type": user.user_type is not None,
+                                    "has_user_language": user.user_language is not None,
+                                }
+                            },
+                        )
                         onboard_convs.append(m)
                 else:
                     self._logger.info("[__create_conversations] no_bot_msg -> conversations (msg_id=%s)", m.message_context.message_id)
@@ -203,6 +238,17 @@ class MessageConsmerService:
                 else:
                     # Missing user fields, needs onboarding
                     self._logger.info("[__create_conversations] missing_user_fields -> onboard (msg_id=%s)", m.message_context.message_id)
+                    AppInsightsLogHandler.getLogger("onboarding_routing").info(
+                        "routed_to_onboard: missing_user_fields",
+                        extra={
+                            AppInsightsLogHandler.DETAILS: {
+                                "reason": "missing_user_fields",
+                                "message_id": m.message_context.message_id,
+                                "phone_number_id": m.user.phone_number_id,
+                                "user_id": getattr(user, "user_id", None),
+                            }
+                        },
+                    )
                     onboard_convs.append(m)
             else:
                 self._logger.info("[__create_conversations] regular_flow -> conversations (msg_id=%s)", m.message_context.message_id)

--- a/byoeb-v1/byoeb/byoeb/services/chat/message_consumer.py
+++ b/byoeb-v1/byoeb/byoeb/services/chat/message_consumer.py
@@ -102,9 +102,9 @@ class MessageConsmerService:
             byoeb_users = await self._user_db_service.get_users(user_ids)
         except Exception as e:
             self._logger.exception(
-                "[__create_conversations] user lookup failed (database/network error): %s", e
+                "[__create_conversations] user lookup failed: %s", e
             )
-            raise
+            byoeb_users = []  # treat all as unknown; onboarding guard below handles them
         self._logger.debug("[__create_conversations] fetched_users=%s", len(byoeb_users))
 
         for m in messages:

--- a/byoeb-v1/byoeb/byoeb/services/chat/message_consumer.py
+++ b/byoeb-v1/byoeb/byoeb/services/chat/message_consumer.py
@@ -103,36 +103,42 @@ class MessageConsmerService:
 
         # Telemetry: detect possible DB/network transient when fewer users returned than requested
         if len(byoeb_users) < len(user_ids):
-            AppInsightsLogHandler.getLogger("onboarding_routing").warning(
-                "user_lookup_returned_fewer_than_requested (possible transient)",
-                extra={
-                    AppInsightsLogHandler.DETAILS: {
-                        "requested_count": len(user_ids),
-                        "fetched_count": len(byoeb_users),
-                        "missing_count": len(user_ids) - len(byoeb_users),
-                    }
-                },
-            )
+            try:
+                AppInsightsLogHandler.getLogger("onboarding_routing").warning(
+                    "user_lookup_returned_fewer_than_requested (possible transient)",
+                    extra={
+                        AppInsightsLogHandler.DETAILS: {
+                            "requested_count": len(user_ids),
+                            "fetched_count": len(byoeb_users),
+                            "missing_count": len(user_ids) - len(byoeb_users),
+                        }
+                    },
+                )
+            except Exception as e:
+                self._logger.warning("[onboarding_routing] telemetry failed: %s", e)
 
         for m in messages:
             user = self.__get_user(byoeb_users, m.user.phone_number_id)
             if user is None:
-                self._logger.info("[__create_conversations] user_not_found phone=%s -> onboard", m.user.phone_number_id)
-                AppInsightsLogHandler.getLogger("onboarding_routing").info(
-                    "routed_to_onboard: user_not_found",
-                    extra={
-                        AppInsightsLogHandler.DETAILS: {
-                            "reason": "user_not_found",
-                            "message_id": m.message_context.message_id,
-                            "phone_number_id": m.user.phone_number_id,
-                        }
-                    },
-                )
+                self._logger.info("[__create_conversations] user_not_found phone=%s -> onboard", utils.mask_phone(getattr(m.user, "phone_number_id", "")))
+                try:
+                    AppInsightsLogHandler.getLogger("onboarding_routing").info(
+                        "routed_to_onboard: user_not_found",
+                        extra={
+                            AppInsightsLogHandler.DETAILS: {
+                                "reason": "user_not_found",
+                                "message_id": m.message_context.message_id,
+                                "phone_number_id": utils.mask_phone(getattr(m.user, "phone_number_id", "")),
+                            }
+                        },
+                    )
+                except Exception as e:
+                    self._logger.warning("[onboarding_routing] telemetry failed: %s", e)
                 onboard_convs.append(m)
                 continue
 
             # minimal peek
-            self._logger.info("[__create_conversations] user_found phone=%s user_type=%s reply_id=%s", m.user.phone_number_id, user.user_type, m.reply_context.reply_id)
+            self._logger.info("[__create_conversations] user_found phone=%s user_type=%s reply_id=%s", utils.mask_phone(getattr(m.user, "phone_number_id", "")), user.user_type, m.reply_context.reply_id)
 
             if self.__is_expert_user_type(user.user_type) and m.reply_context.reply_id is None:
                 # attach last bot message to reply
@@ -185,18 +191,21 @@ class MessageConsmerService:
                     else:
                         # New user needs onboarding
                         self._logger.info("[__create_conversations] no_bot_msg + needs_onboarding -> onboard (msg_id=%s)", m.message_context.message_id)
-                        AppInsightsLogHandler.getLogger("onboarding_routing").info(
-                            "routed_to_onboard: needs_onboarding_no_bot_msg",
-                            extra={
-                                AppInsightsLogHandler.DETAILS: {
-                                    "reason": "needs_onboarding_no_bot_msg",
-                                    "message_id": m.message_context.message_id,
-                                    "phone_number_id": m.user.phone_number_id,
-                                    "has_user_type": user.user_type is not None,
-                                    "has_user_language": user.user_language is not None,
-                                }
-                            },
-                        )
+                        try:
+                            AppInsightsLogHandler.getLogger("onboarding_routing").info(
+                                "routed_to_onboard: needs_onboarding_no_bot_msg",
+                                extra={
+                                    AppInsightsLogHandler.DETAILS: {
+                                        "reason": "needs_onboarding_no_bot_msg",
+                                        "message_id": m.message_context.message_id,
+                                        "phone_number_id": utils.mask_phone(getattr(m.user, "phone_number_id", "")),
+                                        "has_user_type": user.user_type is not None,
+                                        "has_user_language": user.user_language is not None,
+                                    }
+                                },
+                            )
+                        except Exception as e:
+                            self._logger.warning("[onboarding_routing] telemetry failed: %s", e)
                         onboard_convs.append(m)
                 else:
                     self._logger.info("[__create_conversations] no_bot_msg -> conversations (msg_id=%s)", m.message_context.message_id)
@@ -238,17 +247,20 @@ class MessageConsmerService:
                 else:
                     # Missing user fields, needs onboarding
                     self._logger.info("[__create_conversations] missing_user_fields -> onboard (msg_id=%s)", m.message_context.message_id)
-                    AppInsightsLogHandler.getLogger("onboarding_routing").info(
-                        "routed_to_onboard: missing_user_fields",
-                        extra={
-                            AppInsightsLogHandler.DETAILS: {
-                                "reason": "missing_user_fields",
-                                "message_id": m.message_context.message_id,
-                                "phone_number_id": m.user.phone_number_id,
-                                "user_id": getattr(user, "user_id", None),
-                            }
-                        },
-                    )
+                    try:
+                        AppInsightsLogHandler.getLogger("onboarding_routing").info(
+                            "routed_to_onboard: missing_user_fields",
+                            extra={
+                                AppInsightsLogHandler.DETAILS: {
+                                    "reason": "missing_user_fields",
+                                    "message_id": m.message_context.message_id,
+                                    "phone_number_id": utils.mask_phone(getattr(m.user, "phone_number_id", "")),
+                                    "user_id": getattr(user, "user_id", None),
+                                }
+                            },
+                        )
+                    except Exception as e:
+                        self._logger.warning("[onboarding_routing] telemetry failed: %s", e)
                     onboard_convs.append(m)
             else:
                 self._logger.info("[__create_conversations] regular_flow -> conversations (msg_id=%s)", m.message_context.message_id)

--- a/byoeb-v1/byoeb/byoeb/services/user/constants.py
+++ b/byoeb-v1/byoeb/byoeb/services/user/constants.py
@@ -1,4 +1,5 @@
 USER_TYPE = "user_type"
 LANGUAGE_SELECTION = "language_selection"
+REGISTER_PROMPT = "register_prompt"
 CONSENT = "consent"
 THANK_YOU = "thank_you"

--- a/byoeb-v1/byoeb/byoeb/services/user/onboarding.py
+++ b/byoeb-v1/byoeb/byoeb/services/user/onboarding.py
@@ -254,151 +254,52 @@ async def handle_unknown_user(
     if not isinstance(channel_service, WhatsAppService):
         raise ValueError("Invalid channel service type")
     for message in messages:
-        logger.debug("message.reply_context=%s", message.reply_context)
-        # Normalize incoming text once per message so we can use it consistently in guards.
-        msg_text = (message.message_context and message.message_context.message_source_text) or ""
-        user_lang = getattr(message.user, "user_language", None)
-        is_onboarding_intent = utils.is_onboard(msg_text, user_lang)
-
-        # Main guard: only send language selection when the first message is clearly onboarding-like.
-        if (message.reply_context is None or message.reply_context.reply_id is None) and is_onboarding_intent:
-            logger.info("onboarding message: %s", message)
-            try:
-                AppInsightsLogHandler.getLogger("onboarding_guard").info(
-                    "language_selection_sent",
-                    extra={
-                        AppInsightsLogHandler.DETAILS: {
-                            "reason": "language_selection_sent",
-                            "message_id": message.message_context.message_id if message.message_context else None,
-                            "phone_number_id": utils.mask_phone(getattr(message.user, "phone_number_id", "")),
-                        }
-                    },
-                )
-            except Exception as e:
-                logger.warning("[onboarding_guard] telemetry failed: %s", e)
-            byoeb_message = create_language_selection_message(message)
-            requests = channel_service.prepare_requests(byoeb_message)
-            responses, message_ids = await asyncio.wait_for(
-                channel_service.send_requests(requests),
-                timeout=ONBOARDING_SEND_REQUESTS_TIMEOUT_SECONDS,
-            )
-            convs = channel_service.create_conv(byoeb_message, responses)
-            new_user = create_user(phone_number_id=message.user.phone_number_id)
-            logger.info("Created new user %s", new_user.user_id)
-            message_db_queries = {
-                chat_const.CREATE: message_db_service.message_create_queries(convs)
-            }
-            user_db_queries = {
-                chat_const.CREATE: [user_db_service.user_create_query(new_user)]
-            }
-            try:
-                await message_db_service.execute_queries(message_db_queries)
-                await user_db_service.execute_queries(user_db_queries)
-            except Exception as e:
-                logger.error("Error in onboarding message: %s", e, exc_info=True)
-        elif (message.reply_context is None or message.reply_context.reply_id is None):
-            # Guard failure: user is unknown but message is not onboarding-like → send register prompt.
-            logger.info(
-                "onboarding path but message not onboarding-like, sending register prompt: %s",
-                utils.mask_message_preview(msg_text),
-            )
-            # DEBUG: correlate with DB using message_id when investigating a specific case (no raw PII at INFO)
-            logger.debug(
-                "register_prompt context: message_id=%s, phone=%s, msg_len=%d",
-                message.message_context.message_id if message.message_context else None,
-                utils.mask_phone(getattr(message.user, "phone_number_id", "")),
-                len(msg_text),
-            )
-            try:
-                AppInsightsLogHandler.getLogger("onboarding_guard").info(
-                    "register_prompt_sent: message not onboarding-like (possible transient)",
-                    extra={
-                        AppInsightsLogHandler.DETAILS: {
-                            "reason": "register_prompt_not_onboarding_like",
-                            "message_id": message.message_context.message_id if message.message_context else None,
-                            "phone_number_id": utils.mask_phone(getattr(message.user, "phone_number_id", "")),
-                            "message_preview": utils.mask_message_preview(msg_text),
-                        }
-                    },
-                )
-            except Exception as e:
-                logger.warning("[onboarding_guard] telemetry failed: %s", e)
-            byoeb_message = create_register_prompt_message(message)
-            requests = channel_service.prepare_requests(byoeb_message)
-            await asyncio.wait_for(
-                channel_service.send_requests(requests),
-                timeout=ONBOARDING_SEND_REQUESTS_TIMEOUT_SECONDS,
-            )
-            continue
-        elif message.reply_context.message_category == chat_const.LANGUAGE_SELECTION:
-            logger.info("Language Selection")
-            text = message.message_context.message_source_text
-            code = get_language_code(text)
-            update_user = create_user(
-                phone_number_id=message.user.phone_number_id,
-                language=code,
-            )
-            user_db_queries = {
-                chat_const.UPDATE: [user_db_service.user_update_query(update_user)]
-            }
-            byoeb_message = create_user_selection_message(message, code)
-            requests = channel_service.prepare_requests(byoeb_message)
-            responses, message_ids = await asyncio.wait_for(channel_service.send_requests(requests), timeout=ONBOARDING_SEND_REQUESTS_TIMEOUT_SECONDS)
-            convs = channel_service.create_conv(byoeb_message, responses)
-            message_db_queries = {
-                chat_const.CREATE: message_db_service.message_create_queries(convs)
-            }
-            await message_db_service.execute_queries(message_db_queries)
-            await user_db_service.execute_queries(user_db_queries)
-        elif message.reply_context.message_category == chat_const.USER_TYPE:
-            logger.info("User Type")
-            text = message.message_context.message_source_text
-            user_type = get_user_type(text)
-            update_user = create_user(
-                phone_number_id=message.user.phone_number_id,
-                language=message.user.user_language,
-                user_type=user_type,
-            )
-            user_db_queries = {
-                chat_const.UPDATE: [user_db_service.user_update_query(update_user)]
-            }
-            byoeb_message = create_consent_message(message, user_type)
-            requests = channel_service.prepare_requests(byoeb_message)
-            responses, message_ids = await asyncio.wait_for(channel_service.send_requests(requests), timeout=ONBOARDING_SEND_REQUESTS_TIMEOUT_SECONDS)
-            convs = channel_service.create_conv(byoeb_message, responses)
-            message_db_queries = {
-                chat_const.CREATE: message_db_service.message_create_queries(convs)
-            }
-            await message_db_service.execute_queries(message_db_queries)
-            await user_db_service.execute_queries(user_db_queries)
-        elif message.reply_context.message_category == chat_const.CONSENT:
-            logger.info("Consent")
-            text = message.message_context.message_source_text
-            consent = get_consent(text)
-            logger.debug("consent=%s", consent)
-            update_user = create_user(
-                phone_number_id=message.user.phone_number_id,
-                user_type=message.user.user_type,
-                language=message.user.user_language,
-                consent=consent
-            )
-            user_db_queries = {
-                chat_const.UPDATE: [user_db_service.user_update_query(update_user)]
-            }
-            byoeb_message = create_initial_message(message)
-            byoeb_message_no_reply = byoeb_message.model_copy(deep=True)
-            byoeb_message_no_reply.reply_context = None
-            # print(f"Initial message: {byoeb_message}")
-            requests = channel_service.prepare_requests(byoeb_message_no_reply)
-            responses, message_ids = await asyncio.wait_for(channel_service.send_requests(requests), timeout=ONBOARDING_SEND_REQUESTS_TIMEOUT_SECONDS)
-            await user_db_service.execute_queries(user_db_queries)
-        else:
-            # Guard: only send language selection when message is onboarding-like (e.g. "onboard asha")
+        try:
+            logger.debug("message.reply_context=%s", message.reply_context)
+            # Normalize incoming text once per message so we can use it consistently in guards.
             msg_text = (message.message_context and message.message_context.message_source_text) or ""
             user_lang = getattr(message.user, "user_language", None)
             is_onboarding_intent = utils.is_onboard(msg_text, user_lang)
-            if not is_onboarding_intent:
-                logger.info("onboarding fallback but message not onboarding-like, sending register prompt: %s", utils.mask_message_preview(msg_text))
+
+            # Main guard: only send language selection when the first message is clearly onboarding-like.
+            if (message.reply_context is None or message.reply_context.reply_id is None) and is_onboarding_intent:
+                logger.info("onboarding message: %s", message)
+                try:
+                    AppInsightsLogHandler.getLogger("onboarding_guard").info(
+                        "language_selection_sent",
+                        extra={
+                            AppInsightsLogHandler.DETAILS: {
+                                "reason": "language_selection_sent",
+                                "message_id": message.message_context.message_id if message.message_context else None,
+                                "phone_number_id": utils.mask_phone(getattr(message.user, "phone_number_id", "")),
+                            }
+                        },
+                    )
+                except Exception as e:
+                    logger.warning("[onboarding_guard] telemetry failed: %s", e)
+                byoeb_message = create_language_selection_message(message)
+                requests = channel_service.prepare_requests(byoeb_message)
+                responses, message_ids = await asyncio.wait_for(
+                    channel_service.send_requests(requests),
+                    timeout=ONBOARDING_SEND_REQUESTS_TIMEOUT_SECONDS,
+                )
+                convs = channel_service.create_conv(byoeb_message, responses)
+                new_user = create_user(phone_number_id=message.user.phone_number_id)
+                logger.info("Created new user %s", new_user.user_id)
+                message_db_queries = {
+                    chat_const.CREATE: message_db_service.message_create_queries(convs)
+                }
+                user_db_queries = {
+                    chat_const.CREATE: [user_db_service.user_create_query(new_user)]
+                }
+                await message_db_service.execute_queries(message_db_queries)
+                await user_db_service.execute_queries(user_db_queries)
+            elif (message.reply_context is None or message.reply_context.reply_id is None):
+                # Guard failure: user is unknown but message is not onboarding-like → send register prompt.
+                logger.info(
+                    "onboarding path but message not onboarding-like, sending register prompt: %s",
+                    utils.mask_message_preview(msg_text),
+                )
                 logger.debug(
                     "register_prompt context: message_id=%s, phone=%s, msg_len=%d",
                     message.message_context.message_id if message.message_context else None,
@@ -407,10 +308,10 @@ async def handle_unknown_user(
                 )
                 try:
                     AppInsightsLogHandler.getLogger("onboarding_guard").info(
-                        "register_prompt_sent: fallback path, message not onboarding-like (possible transient)",
+                        "register_prompt_sent: message not onboarding-like (possible transient)",
                         extra={
                             AppInsightsLogHandler.DETAILS: {
-                                "reason": "register_prompt_fallback_not_onboarding_like",
+                                "reason": "register_prompt_not_onboarding_like",
                                 "message_id": message.message_context.message_id if message.message_context else None,
                                 "phone_number_id": utils.mask_phone(getattr(message.user, "phone_number_id", "")),
                                 "message_preview": utils.mask_message_preview(msg_text),
@@ -421,22 +322,123 @@ async def handle_unknown_user(
                     logger.warning("[onboarding_guard] telemetry failed: %s", e)
                 byoeb_message = create_register_prompt_message(message)
                 requests = channel_service.prepare_requests(byoeb_message)
-                await asyncio.wait_for(channel_service.send_requests(requests), timeout=ONBOARDING_SEND_REQUESTS_TIMEOUT_SECONDS)
-                continue
-            logger.info("onboarding message fallback: %s", message)
-            byoeb_message = create_language_selection_message(message)
-            requests = channel_service.prepare_requests(byoeb_message)
-            responses, message_ids = await asyncio.wait_for(channel_service.send_requests(requests), timeout=ONBOARDING_SEND_REQUESTS_TIMEOUT_SECONDS)
-            convs = channel_service.create_conv(byoeb_message, responses)
-            new_user = create_user(phone_number_id=message.user.phone_number_id)
-            message_db_queries = {
-                chat_const.CREATE: message_db_service.message_create_queries(convs)
-            }
-            user_db_queries = {
-                chat_const.CREATE: [user_db_service.user_create_query(new_user)]
-            }
-            try:
+                await asyncio.wait_for(
+                    channel_service.send_requests(requests),
+                    timeout=ONBOARDING_SEND_REQUESTS_TIMEOUT_SECONDS,
+                )
+            elif message.reply_context.message_category == chat_const.LANGUAGE_SELECTION:
+                logger.info("Language Selection")
+                text = message.message_context.message_source_text
+                code = get_language_code(text)
+                update_user = create_user(
+                    phone_number_id=message.user.phone_number_id,
+                    language=code,
+                )
+                user_db_queries = {
+                    chat_const.UPDATE: [user_db_service.user_update_query(update_user)]
+                }
+                byoeb_message = create_user_selection_message(message, code)
+                requests = channel_service.prepare_requests(byoeb_message)
+                responses, message_ids = await asyncio.wait_for(channel_service.send_requests(requests), timeout=ONBOARDING_SEND_REQUESTS_TIMEOUT_SECONDS)
+                convs = channel_service.create_conv(byoeb_message, responses)
+                message_db_queries = {
+                    chat_const.CREATE: message_db_service.message_create_queries(convs)
+                }
                 await message_db_service.execute_queries(message_db_queries)
                 await user_db_service.execute_queries(user_db_queries)
-            except Exception as e:
-                logger.error("Error in onboarding message: %s", e, exc_info=True)
+            elif message.reply_context.message_category == chat_const.USER_TYPE:
+                logger.info("User Type")
+                text = message.message_context.message_source_text
+                user_type = get_user_type(text)
+                update_user = create_user(
+                    phone_number_id=message.user.phone_number_id,
+                    language=message.user.user_language,
+                    user_type=user_type,
+                )
+                user_db_queries = {
+                    chat_const.UPDATE: [user_db_service.user_update_query(update_user)]
+                }
+                byoeb_message = create_consent_message(message, user_type)
+                requests = channel_service.prepare_requests(byoeb_message)
+                responses, message_ids = await asyncio.wait_for(channel_service.send_requests(requests), timeout=ONBOARDING_SEND_REQUESTS_TIMEOUT_SECONDS)
+                convs = channel_service.create_conv(byoeb_message, responses)
+                message_db_queries = {
+                    chat_const.CREATE: message_db_service.message_create_queries(convs)
+                }
+                await message_db_service.execute_queries(message_db_queries)
+                await user_db_service.execute_queries(user_db_queries)
+            elif message.reply_context.message_category == chat_const.CONSENT:
+                logger.info("Consent")
+                text = message.message_context.message_source_text
+                consent = get_consent(text)
+                logger.debug("consent=%s", consent)
+                update_user = create_user(
+                    phone_number_id=message.user.phone_number_id,
+                    user_type=message.user.user_type,
+                    language=message.user.user_language,
+                    consent=consent
+                )
+                user_db_queries = {
+                    chat_const.UPDATE: [user_db_service.user_update_query(update_user)]
+                }
+                byoeb_message = create_initial_message(message)
+                byoeb_message_no_reply = byoeb_message.model_copy(deep=True)
+                byoeb_message_no_reply.reply_context = None
+                requests = channel_service.prepare_requests(byoeb_message_no_reply)
+                responses, message_ids = await asyncio.wait_for(channel_service.send_requests(requests), timeout=ONBOARDING_SEND_REQUESTS_TIMEOUT_SECONDS)
+                await user_db_service.execute_queries(user_db_queries)
+            else:
+                # Guard: only send language selection when message is onboarding-like (e.g. "onboard asha")
+                msg_text = (message.message_context and message.message_context.message_source_text) or ""
+                user_lang = getattr(message.user, "user_language", None)
+                is_onboarding_intent = utils.is_onboard(msg_text, user_lang)
+                if not is_onboarding_intent:
+                    logger.info("onboarding fallback but message not onboarding-like, sending register prompt: %s", utils.mask_message_preview(msg_text))
+                    logger.debug(
+                        "register_prompt context: message_id=%s, phone=%s, msg_len=%d",
+                        message.message_context.message_id if message.message_context else None,
+                        utils.mask_phone(getattr(message.user, "phone_number_id", "")),
+                        len(msg_text),
+                    )
+                    try:
+                        AppInsightsLogHandler.getLogger("onboarding_guard").info(
+                            "register_prompt_sent: fallback path, message not onboarding-like (possible transient)",
+                            extra={
+                                AppInsightsLogHandler.DETAILS: {
+                                    "reason": "register_prompt_fallback_not_onboarding_like",
+                                    "message_id": message.message_context.message_id if message.message_context else None,
+                                    "phone_number_id": utils.mask_phone(getattr(message.user, "phone_number_id", "")),
+                                    "message_preview": utils.mask_message_preview(msg_text),
+                                }
+                            },
+                        )
+                    except Exception as e:
+                        logger.warning("[onboarding_guard] telemetry failed: %s", e)
+                    byoeb_message = create_register_prompt_message(message)
+                    requests = channel_service.prepare_requests(byoeb_message)
+                    await asyncio.wait_for(channel_service.send_requests(requests), timeout=ONBOARDING_SEND_REQUESTS_TIMEOUT_SECONDS)
+                else:
+                    logger.info("onboarding message fallback: %s", message)
+                    byoeb_message = create_language_selection_message(message)
+                    requests = channel_service.prepare_requests(byoeb_message)
+                    responses, message_ids = await asyncio.wait_for(channel_service.send_requests(requests), timeout=ONBOARDING_SEND_REQUESTS_TIMEOUT_SECONDS)
+                    convs = channel_service.create_conv(byoeb_message, responses)
+                    new_user = create_user(phone_number_id=message.user.phone_number_id)
+                    message_db_queries = {
+                        chat_const.CREATE: message_db_service.message_create_queries(convs)
+                    }
+                    user_db_queries = {
+                        chat_const.CREATE: [user_db_service.user_create_query(new_user)]
+                    }
+                    await message_db_service.execute_queries(message_db_queries)
+                    await user_db_service.execute_queries(user_db_queries)
+        except (asyncio.TimeoutError, Exception) as e:
+            # asyncio.TimeoutError is a subclass of Exception in all supported Python
+            # versions, but is listed explicitly so it's clear that a slow WhatsApp
+            # send (wait_for timeout) is caught here and will not abort the whole batch.
+            logger.error(
+                "[handle_unknown_user] error processing message %s: %s",
+                message.message_context.message_id if message.message_context else None,
+                e,
+                exc_info=True,
+            )

--- a/byoeb-v1/byoeb/byoeb/services/user/onboarding.py
+++ b/byoeb-v1/byoeb/byoeb/services/user/onboarding.py
@@ -255,39 +255,13 @@ async def handle_unknown_user(
         raise ValueError("Invalid channel service type")
     for message in messages:
         logger.debug("message.reply_context=%s", message.reply_context)
-        if message.reply_context is None or message.reply_context.reply_id is None:
-            # Guard: only send language selection when message is onboarding-like (e.g. "onboard asha")
-            # and user is not found or language not set. Otherwise prompt to register.
-            msg_text = (message.message_context and message.message_context.message_source_text) or ""
-            user_lang = getattr(message.user, "user_language", None)
-            is_onboarding_intent = utils.is_onboard(msg_text, user_lang)
-            if not is_onboarding_intent:
-                logger.info("onboarding path but message not onboarding-like, sending register prompt: %s", utils.mask_message_preview(msg_text))
-                # DEBUG: correlate with DB using message_id when investigating a specific case (no raw PII at INFO)
-                logger.debug(
-                    "register_prompt context: message_id=%s, phone=%s, msg_len=%d",
-                    message.message_context.message_id if message.message_context else None,
-                    utils.mask_phone(getattr(message.user, "phone_number_id", "")),
-                    len(msg_text),
-                )
-                try:
-                    AppInsightsLogHandler.getLogger("onboarding_guard").info(
-                        "register_prompt_sent: message not onboarding-like (possible transient)",
-                        extra={
-                            AppInsightsLogHandler.DETAILS: {
-                                "reason": "register_prompt_not_onboarding_like",
-                                "message_id": message.message_context.message_id if message.message_context else None,
-                                "phone_number_id": utils.mask_phone(getattr(message.user, "phone_number_id", "")),
-                                "message_preview": utils.mask_message_preview(msg_text),
-                            }
-                        },
-                    )
-                except Exception as e:
-                    logger.warning("[onboarding_guard] telemetry failed: %s", e)
-                byoeb_message = create_register_prompt_message(message)
-                requests = channel_service.prepare_requests(byoeb_message)
-                await asyncio.wait_for(channel_service.send_requests(requests), timeout=ONBOARDING_SEND_REQUESTS_TIMEOUT_SECONDS)
-                continue
+        # Normalize incoming text once per message so we can use it consistently in guards.
+        msg_text = (message.message_context and message.message_context.message_source_text) or ""
+        user_lang = getattr(message.user, "user_language", None)
+        is_onboarding_intent = utils.is_onboard(msg_text, user_lang)
+
+        # Main guard: only send language selection when the first message is clearly onboarding-like.
+        if (message.reply_context is None or message.reply_context.reply_id is None) and is_onboarding_intent:
             logger.info("onboarding message: %s", message)
             try:
                 AppInsightsLogHandler.getLogger("onboarding_guard").info(
@@ -304,7 +278,10 @@ async def handle_unknown_user(
                 logger.warning("[onboarding_guard] telemetry failed: %s", e)
             byoeb_message = create_language_selection_message(message)
             requests = channel_service.prepare_requests(byoeb_message)
-            responses, message_ids = await asyncio.wait_for(channel_service.send_requests(requests), timeout=ONBOARDING_SEND_REQUESTS_TIMEOUT_SECONDS)
+            responses, message_ids = await asyncio.wait_for(
+                channel_service.send_requests(requests),
+                timeout=ONBOARDING_SEND_REQUESTS_TIMEOUT_SECONDS,
+            )
             convs = channel_service.create_conv(byoeb_message, responses)
             new_user = create_user(phone_number_id=message.user.phone_number_id)
             logger.info("Created new user %s", new_user.user_id)
@@ -319,6 +296,40 @@ async def handle_unknown_user(
                 await user_db_service.execute_queries(user_db_queries)
             except Exception as e:
                 logger.error("Error in onboarding message: %s", e, exc_info=True)
+        elif (message.reply_context is None or message.reply_context.reply_id is None):
+            # Guard failure: user is unknown but message is not onboarding-like → send register prompt.
+            logger.info(
+                "onboarding path but message not onboarding-like, sending register prompt: %s",
+                utils.mask_message_preview(msg_text),
+            )
+            # DEBUG: correlate with DB using message_id when investigating a specific case (no raw PII at INFO)
+            logger.debug(
+                "register_prompt context: message_id=%s, phone=%s, msg_len=%d",
+                message.message_context.message_id if message.message_context else None,
+                utils.mask_phone(getattr(message.user, "phone_number_id", "")),
+                len(msg_text),
+            )
+            try:
+                AppInsightsLogHandler.getLogger("onboarding_guard").info(
+                    "register_prompt_sent: message not onboarding-like (possible transient)",
+                    extra={
+                        AppInsightsLogHandler.DETAILS: {
+                            "reason": "register_prompt_not_onboarding_like",
+                            "message_id": message.message_context.message_id if message.message_context else None,
+                            "phone_number_id": utils.mask_phone(getattr(message.user, "phone_number_id", "")),
+                            "message_preview": utils.mask_message_preview(msg_text),
+                        }
+                    },
+                )
+            except Exception as e:
+                logger.warning("[onboarding_guard] telemetry failed: %s", e)
+            byoeb_message = create_register_prompt_message(message)
+            requests = channel_service.prepare_requests(byoeb_message)
+            await asyncio.wait_for(
+                channel_service.send_requests(requests),
+                timeout=ONBOARDING_SEND_REQUESTS_TIMEOUT_SECONDS,
+            )
+            continue
         elif message.reply_context.message_category == chat_const.LANGUAGE_SELECTION:
             logger.info("Language Selection")
             text = message.message_context.message_source_text

--- a/byoeb-v1/byoeb/byoeb/services/user/onboarding.py
+++ b/byoeb-v1/byoeb/byoeb/services/user/onboarding.py
@@ -16,6 +16,8 @@ from byoeb.constants.onboarding_text import (
     NO_SET,
     USER_TYPE_OPTIONS,
 )
+from byoeb.utils import utils
+from byoeb.application_logger.azure_app_insights import AppInsightsLogHandler
 from byoeb.factory import ChannelClientFactory
 from byoeb_core.models.byoeb.message_context import (
     ByoebMessageContext,
@@ -111,6 +113,28 @@ def create_language_selection_message(
         ),
         reply_context=make_reply_context(message, "create_language_selection_message"),
     )
+
+
+# Shown when user is in onboarding path but message is not onboarding-like (e.g. not "onboard asha").
+REGISTER_PROMPT_TEXT = (
+    "To register with ASHA Saheli, please send 'onboard asha' or a similar phrase in your language."
+)
+
+
+def create_register_prompt_message(message: ByoebMessageContext) -> ByoebMessageContext:
+    """Simple text reply asking user to send onboarding phrase to start registration."""
+    return ByoebMessageContext(
+        channel_type=message.channel_type,
+        message_category=user_const.LANGUAGE_SELECTION,
+        user=message.user,
+        message_context=MessageContext(
+            message_type=MessageTypes.REGULAR_TEXT.value,
+            message_source_text=REGISTER_PROMPT_TEXT,
+            additional_info={},
+        ),
+        reply_context=make_reply_context(message, "create_register_prompt_message"),
+    )
+
 
 def map_user_type(user_type: Optional[str]) -> Optional[str]:
     if user_type is None:
@@ -233,7 +257,39 @@ async def handle_unknown_user(
     for message in messages:
         logger.debug("message.reply_context=%s", message.reply_context)
         if message.reply_context is None or message.reply_context.reply_id is None:
+            # Guard: only send language selection when message is onboarding-like (e.g. "onboard asha")
+            # and user is not found or language not set. Otherwise prompt to register.
+            msg_text = (message.message_context and message.message_context.message_source_text) or ""
+            user_lang = getattr(message.user, "user_language", None)
+            is_onboarding_intent = utils.is_onboard(msg_text, user_lang)
+            if not is_onboarding_intent:
+                logger.info("onboarding path but message not onboarding-like, sending register prompt: %s", msg_text[:80])
+                AppInsightsLogHandler.getLogger("onboarding_guard").info(
+                    "register_prompt_sent: message not onboarding-like (possible transient)",
+                    extra={
+                        AppInsightsLogHandler.DETAILS: {
+                            "reason": "register_prompt_not_onboarding_like",
+                            "message_id": message.message_context.message_id if message.message_context else None,
+                            "phone_number_id": getattr(message.user, "phone_number_id", None),
+                            "message_preview": (msg_text[:80] + "…") if len(msg_text) > 80 else msg_text,
+                        }
+                    },
+                )
+                byoeb_message = create_register_prompt_message(message)
+                requests = channel_service.prepare_requests(byoeb_message)
+                await channel_service.send_requests(requests)
+                continue
             logger.info("onboarding message: %s", message)
+            AppInsightsLogHandler.getLogger("onboarding_guard").info(
+                "language_selection_sent",
+                extra={
+                    AppInsightsLogHandler.DETAILS: {
+                        "reason": "language_selection_sent",
+                        "message_id": message.message_context.message_id if message.message_context else None,
+                        "phone_number_id": getattr(message.user, "phone_number_id", None),
+                    }
+                },
+            )
             byoeb_message = create_language_selection_message(message)
             requests = channel_service.prepare_requests(byoeb_message)
             responses, message_ids = await channel_service.send_requests(requests)
@@ -314,6 +370,27 @@ async def handle_unknown_user(
             responses, message_ids = await channel_service.send_requests(requests)
             await user_db_service.execute_queries(user_db_queries)
         else:
+            # Guard: only send language selection when message is onboarding-like (e.g. "onboard asha")
+            msg_text = (message.message_context and message.message_context.message_source_text) or ""
+            user_lang = getattr(message.user, "user_language", None)
+            is_onboarding_intent = utils.is_onboard(msg_text, user_lang)
+            if not is_onboarding_intent:
+                logger.info("onboarding fallback but message not onboarding-like, sending register prompt: %s", msg_text[:80])
+                AppInsightsLogHandler.getLogger("onboarding_guard").info(
+                    "register_prompt_sent: fallback path, message not onboarding-like (possible transient)",
+                    extra={
+                        AppInsightsLogHandler.DETAILS: {
+                            "reason": "register_prompt_fallback_not_onboarding_like",
+                            "message_id": message.message_context.message_id if message.message_context else None,
+                            "phone_number_id": getattr(message.user, "phone_number_id", None),
+                            "message_preview": (msg_text[:80] + "…") if len(msg_text) > 80 else msg_text,
+                        }
+                    },
+                )
+                byoeb_message = create_register_prompt_message(message)
+                requests = channel_service.prepare_requests(byoeb_message)
+                await channel_service.send_requests(requests)
+                continue
             logger.info("onboarding message fallback: %s", message)
             byoeb_message = create_language_selection_message(message)
             requests = channel_service.prepare_requests(byoeb_message)

--- a/byoeb-v1/byoeb/byoeb/services/user/onboarding.py
+++ b/byoeb-v1/byoeb/byoeb/services/user/onboarding.py
@@ -12,6 +12,7 @@ from byoeb.constants.onboarding_text import (
     CONSENT_DICT,
     THANK_YOU_DICT,
     RELATED_QUESTIONS,
+    REGISTER_PROMPT_TEXT,
     YES_SET,
     NO_SET,
     USER_TYPE_OPTIONS,
@@ -31,8 +32,12 @@ from byoeb_core.models.byoeb.user import User
 from datetime import datetime, timezone
 from byoeb_core.convertor.audio_convertor import wav_to_ogg_opus_bytes
 from byoeb_core.models.whatsapp.requests import media_request as wa_media
+import asyncio
 
 logger = logging.getLogger(__name__)
+
+# Timeout for outbound channel (e.g. WhatsApp) send in onboarding
+ONBOARDING_SEND_REQUESTS_TIMEOUT_SECONDS = 30
 
 def get_language_code(language):
     return LANGUAGE_NAME_TO_CODE.get(language)
@@ -113,12 +118,6 @@ def create_language_selection_message(
         ),
         reply_context=make_reply_context(message, "create_language_selection_message"),
     )
-
-
-# Shown when user is in onboarding path but message is not onboarding-like (e.g. not "onboard asha").
-REGISTER_PROMPT_TEXT = (
-    "To register with ASHA Saheli, please send 'onboard asha' or a similar phrase in your language."
-)
 
 
 def create_register_prompt_message(message: ByoebMessageContext) -> ByoebMessageContext:
@@ -263,36 +262,49 @@ async def handle_unknown_user(
             user_lang = getattr(message.user, "user_language", None)
             is_onboarding_intent = utils.is_onboard(msg_text, user_lang)
             if not is_onboarding_intent:
-                logger.info("onboarding path but message not onboarding-like, sending register prompt: %s", msg_text[:80])
+                logger.info("onboarding path but message not onboarding-like, sending register prompt: %s", utils.mask_message_preview(msg_text))
+                # DEBUG: correlate with DB using message_id when investigating a specific case (no raw PII at INFO)
+                logger.debug(
+                    "register_prompt context: message_id=%s, phone=%s, msg_len=%d",
+                    message.message_context.message_id if message.message_context else None,
+                    utils.mask_phone(getattr(message.user, "phone_number_id", "")),
+                    len(msg_text),
+                )
+                try:
+                    AppInsightsLogHandler.getLogger("onboarding_guard").info(
+                        "register_prompt_sent: message not onboarding-like (possible transient)",
+                        extra={
+                            AppInsightsLogHandler.DETAILS: {
+                                "reason": "register_prompt_not_onboarding_like",
+                                "message_id": message.message_context.message_id if message.message_context else None,
+                                "phone_number_id": utils.mask_phone(getattr(message.user, "phone_number_id", "")),
+                                "message_preview": utils.mask_message_preview(msg_text),
+                            }
+                        },
+                    )
+                except Exception as e:
+                    logger.warning("[onboarding_guard] telemetry failed: %s", e)
+                byoeb_message = create_register_prompt_message(message)
+                requests = channel_service.prepare_requests(byoeb_message)
+                await asyncio.wait_for(channel_service.send_requests(requests), timeout=ONBOARDING_SEND_REQUESTS_TIMEOUT_SECONDS)
+                continue
+            logger.info("onboarding message: %s", message)
+            try:
                 AppInsightsLogHandler.getLogger("onboarding_guard").info(
-                    "register_prompt_sent: message not onboarding-like (possible transient)",
+                    "language_selection_sent",
                     extra={
                         AppInsightsLogHandler.DETAILS: {
-                            "reason": "register_prompt_not_onboarding_like",
+                            "reason": "language_selection_sent",
                             "message_id": message.message_context.message_id if message.message_context else None,
-                            "phone_number_id": getattr(message.user, "phone_number_id", None),
-                            "message_preview": (msg_text[:80] + "…") if len(msg_text) > 80 else msg_text,
+                            "phone_number_id": utils.mask_phone(getattr(message.user, "phone_number_id", "")),
                         }
                     },
                 )
-                byoeb_message = create_register_prompt_message(message)
-                requests = channel_service.prepare_requests(byoeb_message)
-                await channel_service.send_requests(requests)
-                continue
-            logger.info("onboarding message: %s", message)
-            AppInsightsLogHandler.getLogger("onboarding_guard").info(
-                "language_selection_sent",
-                extra={
-                    AppInsightsLogHandler.DETAILS: {
-                        "reason": "language_selection_sent",
-                        "message_id": message.message_context.message_id if message.message_context else None,
-                        "phone_number_id": getattr(message.user, "phone_number_id", None),
-                    }
-                },
-            )
+            except Exception as e:
+                logger.warning("[onboarding_guard] telemetry failed: %s", e)
             byoeb_message = create_language_selection_message(message)
             requests = channel_service.prepare_requests(byoeb_message)
-            responses, message_ids = await channel_service.send_requests(requests)
+            responses, message_ids = await asyncio.wait_for(channel_service.send_requests(requests), timeout=ONBOARDING_SEND_REQUESTS_TIMEOUT_SECONDS)
             convs = channel_service.create_conv(byoeb_message, responses)
             new_user = create_user(phone_number_id=message.user.phone_number_id)
             logger.info("Created new user %s", new_user.user_id)
@@ -320,7 +332,7 @@ async def handle_unknown_user(
             }
             byoeb_message = create_user_selection_message(message, code)
             requests = channel_service.prepare_requests(byoeb_message)
-            responses, message_ids = await channel_service.send_requests(requests)
+            responses, message_ids = await asyncio.wait_for(channel_service.send_requests(requests), timeout=ONBOARDING_SEND_REQUESTS_TIMEOUT_SECONDS)
             convs = channel_service.create_conv(byoeb_message, responses)
             message_db_queries = {
                 chat_const.CREATE: message_db_service.message_create_queries(convs)
@@ -341,7 +353,7 @@ async def handle_unknown_user(
             }
             byoeb_message = create_consent_message(message, user_type)
             requests = channel_service.prepare_requests(byoeb_message)
-            responses, message_ids = await channel_service.send_requests(requests)
+            responses, message_ids = await asyncio.wait_for(channel_service.send_requests(requests), timeout=ONBOARDING_SEND_REQUESTS_TIMEOUT_SECONDS)
             convs = channel_service.create_conv(byoeb_message, responses)
             message_db_queries = {
                 chat_const.CREATE: message_db_service.message_create_queries(convs)
@@ -367,7 +379,7 @@ async def handle_unknown_user(
             byoeb_message_no_reply.reply_context = None
             # print(f"Initial message: {byoeb_message}")
             requests = channel_service.prepare_requests(byoeb_message_no_reply)
-            responses, message_ids = await channel_service.send_requests(requests)
+            responses, message_ids = await asyncio.wait_for(channel_service.send_requests(requests), timeout=ONBOARDING_SEND_REQUESTS_TIMEOUT_SECONDS)
             await user_db_service.execute_queries(user_db_queries)
         else:
             # Guard: only send language selection when message is onboarding-like (e.g. "onboard asha")
@@ -375,26 +387,35 @@ async def handle_unknown_user(
             user_lang = getattr(message.user, "user_language", None)
             is_onboarding_intent = utils.is_onboard(msg_text, user_lang)
             if not is_onboarding_intent:
-                logger.info("onboarding fallback but message not onboarding-like, sending register prompt: %s", msg_text[:80])
-                AppInsightsLogHandler.getLogger("onboarding_guard").info(
-                    "register_prompt_sent: fallback path, message not onboarding-like (possible transient)",
-                    extra={
-                        AppInsightsLogHandler.DETAILS: {
-                            "reason": "register_prompt_fallback_not_onboarding_like",
-                            "message_id": message.message_context.message_id if message.message_context else None,
-                            "phone_number_id": getattr(message.user, "phone_number_id", None),
-                            "message_preview": (msg_text[:80] + "…") if len(msg_text) > 80 else msg_text,
-                        }
-                    },
+                logger.info("onboarding fallback but message not onboarding-like, sending register prompt: %s", utils.mask_message_preview(msg_text))
+                logger.debug(
+                    "register_prompt context: message_id=%s, phone=%s, msg_len=%d",
+                    message.message_context.message_id if message.message_context else None,
+                    utils.mask_phone(getattr(message.user, "phone_number_id", "")),
+                    len(msg_text),
                 )
+                try:
+                    AppInsightsLogHandler.getLogger("onboarding_guard").info(
+                        "register_prompt_sent: fallback path, message not onboarding-like (possible transient)",
+                        extra={
+                            AppInsightsLogHandler.DETAILS: {
+                                "reason": "register_prompt_fallback_not_onboarding_like",
+                                "message_id": message.message_context.message_id if message.message_context else None,
+                                "phone_number_id": utils.mask_phone(getattr(message.user, "phone_number_id", "")),
+                                "message_preview": utils.mask_message_preview(msg_text),
+                            }
+                        },
+                    )
+                except Exception as e:
+                    logger.warning("[onboarding_guard] telemetry failed: %s", e)
                 byoeb_message = create_register_prompt_message(message)
                 requests = channel_service.prepare_requests(byoeb_message)
-                await channel_service.send_requests(requests)
+                await asyncio.wait_for(channel_service.send_requests(requests), timeout=ONBOARDING_SEND_REQUESTS_TIMEOUT_SECONDS)
                 continue
             logger.info("onboarding message fallback: %s", message)
             byoeb_message = create_language_selection_message(message)
             requests = channel_service.prepare_requests(byoeb_message)
-            responses, message_ids = await channel_service.send_requests(requests)
+            responses, message_ids = await asyncio.wait_for(channel_service.send_requests(requests), timeout=ONBOARDING_SEND_REQUESTS_TIMEOUT_SECONDS)
             convs = channel_service.create_conv(byoeb_message, responses)
             new_user = create_user(phone_number_id=message.user.phone_number_id)
             message_db_queries = {

--- a/byoeb-v1/byoeb/byoeb/services/user/onboarding.py
+++ b/byoeb-v1/byoeb/byoeb/services/user/onboarding.py
@@ -124,14 +124,15 @@ def create_register_prompt_message(message: ByoebMessageContext) -> ByoebMessage
     """Simple text reply asking user to send onboarding phrase to start registration."""
     return ByoebMessageContext(
         channel_type=message.channel_type,
-        message_category=user_const.LANGUAGE_SELECTION,
+        # Distinct from LANGUAGE_SELECTION so quoted replies are not parsed as language names.
+        message_category=user_const.REGISTER_PROMPT,
         user=message.user,
         message_context=MessageContext(
             message_type=MessageTypes.REGULAR_TEXT.value,
             message_source_text=REGISTER_PROMPT_TEXT,
             additional_info={},
         ),
-        reply_context=make_reply_context(message, "create_register_prompt_message"),
+        reply_context=None,
     )
 
 
@@ -326,6 +327,66 @@ async def handle_unknown_user(
                     channel_service.send_requests(requests),
                     timeout=ONBOARDING_SEND_REQUESTS_TIMEOUT_SECONDS,
                 )
+            elif message.reply_context.message_category == chat_const.REGISTER_PROMPT:
+                # Reply to register prompt (quoted message). Treat like a fresh guard: only
+                # language list if text is onboarding-like; otherwise re-send register prompt.
+                if is_onboarding_intent:
+                    logger.info("register_prompt reply is onboarding-like: %s", message)
+                    try:
+                        AppInsightsLogHandler.getLogger("onboarding_guard").info(
+                            "language_selection_sent",
+                            extra={
+                                AppInsightsLogHandler.DETAILS: {
+                                    "reason": "language_selection_after_register_prompt",
+                                    "message_id": message.message_context.message_id if message.message_context else None,
+                                    "phone_number_id": utils.mask_phone(getattr(message.user, "phone_number_id", "")),
+                                }
+                            },
+                        )
+                    except Exception as e:
+                        logger.warning("[onboarding_guard] telemetry failed: %s", e)
+                    byoeb_message = create_language_selection_message(message)
+                    requests = channel_service.prepare_requests(byoeb_message)
+                    responses, message_ids = await asyncio.wait_for(
+                        channel_service.send_requests(requests),
+                        timeout=ONBOARDING_SEND_REQUESTS_TIMEOUT_SECONDS,
+                    )
+                    convs = channel_service.create_conv(byoeb_message, responses)
+                    new_user = create_user(phone_number_id=message.user.phone_number_id)
+                    logger.info("Created new user %s", new_user.user_id)
+                    message_db_queries = {
+                        chat_const.CREATE: message_db_service.message_create_queries(convs)
+                    }
+                    user_db_queries = {
+                        chat_const.CREATE: [user_db_service.user_create_query(new_user)]
+                    }
+                    await message_db_service.execute_queries(message_db_queries)
+                    await user_db_service.execute_queries(user_db_queries)
+                else:
+                    logger.info(
+                        "reply to register_prompt not onboarding-like, re-sending register prompt: %s",
+                        utils.mask_message_preview(msg_text),
+                    )
+                    try:
+                        AppInsightsLogHandler.getLogger("onboarding_guard").info(
+                            "register_prompt_sent: reply to register prompt not onboarding-like",
+                            extra={
+                                AppInsightsLogHandler.DETAILS: {
+                                    "reason": "register_prompt_replied_not_onboarding_like",
+                                    "message_id": message.message_context.message_id if message.message_context else None,
+                                    "phone_number_id": utils.mask_phone(getattr(message.user, "phone_number_id", "")),
+                                    "message_preview": utils.mask_message_preview(msg_text),
+                                }
+                            },
+                        )
+                    except Exception as e:
+                        logger.warning("[onboarding_guard] telemetry failed: %s", e)
+                    byoeb_message = create_register_prompt_message(message)
+                    requests = channel_service.prepare_requests(byoeb_message)
+                    await asyncio.wait_for(
+                        channel_service.send_requests(requests),
+                        timeout=ONBOARDING_SEND_REQUESTS_TIMEOUT_SECONDS,
+                    )
             elif message.reply_context.message_category == chat_const.LANGUAGE_SELECTION:
                 logger.info("Language Selection")
                 text = message.message_context.message_source_text

--- a/byoeb-v1/byoeb/byoeb/utils/utils.py
+++ b/byoeb-v1/byoeb/byoeb/utils/utils.py
@@ -17,6 +17,27 @@ from pydantic import TypeAdapter, ValidationError
 
 logger = logging.getLogger(__name__)
 
+
+def mask_phone(phone: str, visible_tail: int = 4) -> str:
+    """Mask phone number for logs/telemetry: show only last visible_tail chars, rest as asterisks."""
+    if not phone or not isinstance(phone, str):
+        return "****"
+    s = str(phone).strip()
+    if len(s) <= visible_tail:
+        return "*" * len(s) if s else "****"
+    return "*" * (len(s) - visible_tail) + s[-visible_tail:]
+
+
+def mask_message_preview(text: str, max_visible: int = 0) -> str:
+    """Redact message content for logs/telemetry. Returns [redacted] or [len=N] to avoid PII."""
+    if not text or not isinstance(text, str):
+        return "[redacted]"
+    n = len(text.strip())
+    if max_visible <= 0:
+        return "[len=%d]" % n
+    return "[len=%d]" % n
+
+
 def get_git_root_path():
     current_dir = os.path.abspath(__file__)
     try:

--- a/byoeb-v1/byoeb/tests/integration/test_onboarding.py
+++ b/byoeb-v1/byoeb/tests/integration/test_onboarding.py
@@ -172,7 +172,7 @@ def test_whatsapp_onboarding_flow(language_display: str, user_type_choice: str, 
         if state == START:
             message_id = generate_message_id()
             timestamp = get_current_timestamp()
-            payload = _text_message_payload(message_id=message_id, timestamp=timestamp, text="hi")
+            payload = _text_message_payload(message_id=message_id, timestamp=timestamp, text="onboard-asha")
 
             requests.post(BASE_URL, json=payload, timeout=HTTP_REQUEST_TIMEOUT_S).raise_for_status()
             url = BASE_URL.replace("receive", "get_bot_messages?timestamp=") + str(timestamp)

--- a/byoeb-v1/byoeb/tests/unit/services/test_onboarding.py
+++ b/byoeb-v1/byoeb/tests/unit/services/test_onboarding.py
@@ -150,6 +150,44 @@ async def test_first_message_non_onboarding_sends_register_prompt_no_user(mock_s
     assert len(msg_db.executed) == 0
 
 @pytest.mark.asyncio
+async def test_register_prompt_reply_onboarding_like_sends_language_selection(mock_services):
+    """Reply to register prompt with onboarding text runs language selection (not get_language_code)."""
+    msg_db, user_db, channel_factory = mock_services
+
+    user = make_user(phone="919555555555")
+    msg = make_msg(
+        user,
+        category=chat_const.REGISTER_PROMPT,
+        text="onboard asha",
+    )
+
+    await mod.handle_unknown_user([msg], msg_db, user_db, channel_factory)
+
+    assert len(user_db.created) == 1
+    assert len(msg_db.created) == 1
+    assert len(msg_db.executed) == 1
+
+
+@pytest.mark.asyncio
+async def test_register_prompt_reply_not_onboarding_resends_prompt_no_db(mock_services):
+    """Reply to register prompt with non-onboarding text re-sends prompt without user/message DB writes."""
+    msg_db, user_db, channel_factory = mock_services
+
+    user = make_user(phone="919666666666")
+    msg = make_msg(
+        user,
+        category=chat_const.REGISTER_PROMPT,
+        text="hello there",
+    )
+
+    await mod.handle_unknown_user([msg], msg_db, user_db, channel_factory)
+
+    assert len(user_db.created) == 0
+    assert len(user_db.updated) == 0
+    assert len(msg_db.executed) == 0
+
+
+@pytest.mark.asyncio
 async def test_language_selection_sends_user_type_buttons_and_updates_user_lang(mock_services):
     msg_db, user_db, channel_factory = mock_services
 

--- a/byoeb-v1/byoeb/tests/unit/services/test_onboarding.py
+++ b/byoeb-v1/byoeb/tests/unit/services/test_onboarding.py
@@ -122,6 +122,22 @@ def test_get_user_type():
 
 @pytest.mark.asyncio
 async def test_first_message_triggers_language_selection(mock_services):
+    """Onboarding-like first message (e.g. 'onboard asha') creates user and sends language selection."""
+    msg_db, user_db, channel_factory = mock_services
+
+    user = make_user(phone="919111111111")
+    msg = make_msg(user, category=None, text="onboard asha")
+
+    await mod.handle_unknown_user([msg], msg_db, user_db, channel_factory)
+
+    assert len(user_db.created) == 1
+    assert len(msg_db.created) == 1
+    assert len(msg_db.executed) == 1
+
+
+@pytest.mark.asyncio
+async def test_first_message_non_onboarding_sends_register_prompt_no_user(mock_services):
+    """First message that is not onboarding-like (e.g. 'hi') sends register prompt and does not create user."""
     msg_db, user_db, channel_factory = mock_services
 
     user = make_user(phone="919111111111")
@@ -129,9 +145,9 @@ async def test_first_message_triggers_language_selection(mock_services):
 
     await mod.handle_unknown_user([msg], msg_db, user_db, channel_factory)
 
-    assert len(user_db.created) == 1
-    assert len(msg_db.created) == 1
-    assert len(msg_db.executed) == 1
+    assert len(user_db.created) == 0
+    # Register prompt is sent via channel; msg_db may or may not record it depending on flow
+    assert len(msg_db.executed) == 0
 
 @pytest.mark.asyncio
 async def test_language_selection_sends_user_type_buttons_and_updates_user_lang(mock_services):


### PR DESCRIPTION
## Issue
Under load, transient DB/network issues sometimes make user lookup fail or return empty. The system then treated the user as not onboarded and, for **any** message, sent the **language selection** screen. So already onboarded users asking normal questions could see language selection because of a temporary lookup failure.

## Fix
- **Guard:** We only send **language selection** when the incoming message is **onboarding-like** (e.g. "onboard asha", "onboard-anm", "onboard-others", or supported phrases in Hindi/Marathi/Telugu). If the message is not onboarding-like, we send a short **register prompt** ("To register, send 'onboard asha'…") and do not create a user. So transient "user not found" no longer forces language selection for random messages.
- **Phrases:** Added "onboard anm", "onboard-anm", "onboard others", "onboard-others" (and English uppercase variants) to `ONBOARD_WELCOME_MESSAGE_DICT`.
- **Telemetry:** Emit `onboarding_routing` and `onboarding_guard` events to Azure (App Insights) when: user lookup returns fewer users than requested, when we route to onboard (with reason), and when we send register prompt vs language selection, so we can detect and alert on transients.

## Files changed
- `byoeb/services/user/onboarding.py` – guard + register prompt + telemetry
- `byoeb/services/chat/message_consumer.py` – onboarding routing telemetry
- `byoeb/constants/onboarding_text.py` – onboard-anm/onboard-others phrases