### PR TITLE
fix: add missing --use-mcp / --mcp-timeout args to run_release_qa_benchmark.py

### DIFF
--- a/byoeb-v1/byoeb/tests/integration/run_release_qa_benchmark.py
+++ b/byoeb-v1/byoeb/tests/integration/run_release_qa_benchmark.py
@@ -256,7 +256,24 @@ def main() -> int:
         default=90,
         help="Timeout in seconds for each MCP call (default: 90)",
     )
+    # --use-mcp: accepted for CI compatibility; script always uses MCP mode.
+    parser.add_argument(
+        "--use-mcp",
+        action="store_true",
+        help="Use MCP asha_chat tool (default and only mode; flag accepted for CI compatibility)",
+    )
+    # --mcp-timeout: CI-friendly alias for --timeout.
+    parser.add_argument(
+        "--mcp-timeout",
+        type=int,
+        default=None,
+        dest="mcp_timeout",
+        help="Timeout in seconds for each MCP call; overrides --timeout when provided",
+    )
     args = parser.parse_args()
+    # Let --mcp-timeout override --timeout if explicitly supplied
+    if args.mcp_timeout is not None:
+        args.timeout = args.mcp_timeout
 
     base_url = args.base_url
     if not base_url.startswith("http"):


### PR DESCRIPTION
## Problem
The CI workflow (`integration-tests.yml`) invokes `run_release_qa_benchmark.py`
with `--use-mcp --mcp-timeout 120`, but neither argument was defined in the
script's `argparse` setup. This caused:

  run_release_qa_benchmark.py: error: unrecognized arguments: --use-mcp --mcp-timeout 320

The benchmark step failed immediately without running any questions.

## Fix
- `--use-mcp` — accepted as a no-op `store_true` flag. The script already
  exclusively uses MCP mode (`run_one_question_mcp`); the flag just makes
  the CI invocation valid.
- `--mcp-timeout` — CI-friendly alias that overrides `--timeout` when
  provided, so `--mcp-timeout 120` correctly sets the per-question timeout
  instead of silently falling back to the 90 s default.

## Test
poetry run python tests/integration/run_release_qa_benchmark.py \
  --use-mcp --mcp-timeout 120 --quiet --help
