### PR TITLE
Remove query text disambiguation

### DIFF
--- a/byoeb-v1/byoeb/byoeb/services/chat/message_handlers/user_flow_handlers/generate.py
+++ b/byoeb-v1/byoeb/byoeb/services/chat/message_handlers/user_flow_handlers/generate.py
@@ -1012,17 +1012,6 @@ class ByoebUserGenerateResponse(Handler):
                                 break
                         exp_span.set_attribute("duration_ms", int((time.perf_counter() - exp_start) * 1000))
 
-                if utils.is_idk(response_en) and (FeatureFlag.QUERY_DISAMBIGUATION in feature_flags or message.user.test_user):
-                    logger.debug("Query expansion was unsuccessful, assessing whether clarification is required...")
-                    with self._tracer.start_as_current_span(SPAN_NEEDS_CLARIFICATION) as clar_span:
-                        clar_span.set_attribute("message_id", msg_id)
-                        clar_start = time.perf_counter()
-                        clarification = await self.needs_clarification(message_english, query_type, user_language, retrieved_chunks)
-                        clar_span.set_attribute("clarification_asked", clarification is not None)
-                        clar_span.set_attribute("duration_ms", int((time.perf_counter() - clar_start) * 1000))
-                    if clarification:
-                        default_message_category = MessageCategory.AUDIO_DISAMBIGUATION if message.message_context.message_type == MessageTypes.REGULAR_AUDIO else MessageCategory.TEXT_DISAMBIGUATION
-                        response_en, response_source, tokens = clarification
 
                 with self._tracer.start_as_current_span(SPAN_RELATED_QUESTIONS) as rq_span:
                     rq_span.set_attribute("message_id", msg_id)


### PR DESCRIPTION
## Summary

- Removes the query disambiguation step from the user message generate flow
- When query expansion fails and the response is still IDK, the bot now returns an IDK answer directly instead of prompting the user to clarify their question
- Eliminates an extra LLM call on IDK paths, reducing latency and cost

## Change

Deleted the 11-line disambiguation block in `ByoebUserGenerateResponse.handle_message_generate_workflow` (`generate.py` lines 1015–1025). The `needs_clarification` method, `MessageCategory.TEXT_DISAMBIGUATION`/`AUDIO_DISAMBIGUATION` enums, and `FeatureFlag.QUERY_DISAMBIGUATION` are left in place as dead code and can be cleaned up in a follow-up.

## Test plan

- [ ] Send a query that previously triggered disambiguation (out-of-scope / ambiguous health question) and confirm the bot returns an IDK response instead of a clarifying question
- [ ] Confirm normal (non-IDK) query responses are unaffected