### PR TITLE
fix: idk responses raise AttributeError

### DIFF
--- a/byoeb-v1/byoeb/byoeb/services/chat/message_handlers/user_flow_handlers/generate.py
+++ b/byoeb-v1/byoeb/byoeb/services/chat/message_handlers/user_flow_handlers/generate.py
@@ -602,17 +602,21 @@ class ByoebUserGenerateResponse(Handler):
         query_type: str,
         vector_search_queries: list[tuple[str | None, str, int]] | None = None
     ) -> tuple[str, str, dict[str, int], list[Chunk]]:
-        def parse_response_xml(xml_string: str):
-            # Patterns for extracting response_en and response_hi
+        def parse_response_xml(xml_string: str) -> tuple[str, str]:
+            # "If ANY of the following conditions are true, respond with <response_idk>I do not know the answer to your question.</response_idk> in these exact words"
+            if (match := re.search(r"<response_idk\s*>(.*?)</response_idk\s*>", xml_string, re.DOTALL | re.IGNORECASE)) is not None:
+                response = match.group(1).strip()
+                return response, response
+
             patterns = {
                 "response_en": r"<response_en\s*>(.*?)</response_en\s*>",
                 "response_src": r"<response_src\s*>(.*?)</response_src\s*>",
             }
-
             extracted_data = {}
             for key, pattern in patterns.items():
                 match = re.search(pattern, xml_string, re.DOTALL | re.IGNORECASE)  # Supports multiline and case-insensitive matches
-                extracted_data[key] = match.group(1).strip() if match else None  # Strip removes extra spaces and newlines
+                if match is None or not match.group(1).strip(): raise ValueError("Parsing failed, did not match pattern '%s' (%s) in output" % (pattern, key))
+                extracted_data[key] = match.group(1).strip()  # Strip removes extra spaces and newlines
 
             return extracted_data["response_en"], extracted_data["response_src"]
 
@@ -655,11 +659,6 @@ class ByoebUserGenerateResponse(Handler):
         logger.debug("[agenerate_answer] Generated answer_en: %s...", response_en[:100] if response_en else 'None')
         logger.debug("[agenerate_answer] Generated answer_source (for language %s): %s...", user_language, response_source[:100] if response_source else 'None')
         logger.debug("[agenerate_answer] Query type: %s", query_type)
-        if response_en is None or query_type is None:
-            raise ValueError("Parsing failed, response or query_type is None.")
-        # Log warning if response_source is None or empty for non-English languages
-        if (response_source is None or not response_source.strip()) and user_language not in ["en", "hi"]:
-            logger.warning("[agenerate_answer] WARNING: response_source is None or empty for language %s. Will fall back to translation from English.", user_language)
         return response_en, response_source, tokens, list(retrieved_chunks.values())
 
     async def needs_clarification(self, query: str, query_type: str, user_language: str, retrieved_chunks: list[Chunk]) -> Optional[tuple[str, str, dict[str, int]]]:

--- a/byoeb-v1/byoeb/byoeb/services/chat/message_handlers/user_flow_handlers/generate.py
+++ b/byoeb-v1/byoeb/byoeb/services/chat/message_handlers/user_flow_handlers/generate.py
@@ -873,6 +873,8 @@ class ByoebUserGenerateResponse(Handler):
             
             user_language = message.user.user_language
             query_type = message.message_context.additional_info.get(constants.QUERY_TYPE)
+            if query_type is None:
+                raise ValueError("query_type must not be None")
             
             default_message_category = None
             cache_hit = False


### PR DESCRIPTION
agenerate-answer's response parser has missing condition for the following case:
> _If ANY of the following conditions are true, respond with <response_idk>I do not know the answer to your question.</response_idk> in these exact words..._

Parser always attempts to parse <response_en> and <response_src> tags, even in the above scenario where those tags would rightfully not exist. This causes the following error:
> AttributeError: 'NoneType' object has no attribute 'lower'

In short, every IDK response triggers 3 failed retries. And on exhausting all failed attempts, ASHABot falls back to IDK. This is not the intended behaviour. This PR properly parses the IDK tag so we need not perform those redundant retries.