### PR TITLE
fix(deps): pin lancedb to 0.26.0 to prevent CI breakage

### DIFF
--- a/byoeb-v1/byoeb/pyproject.toml
+++ b/byoeb-v1/byoeb/pyproject.toml
@@ -27,6 +27,7 @@ matplotlib = "^3.8.0"
 mongomock-motor = "^0.0.36"
 pysqlite3-binary = {version = "^0.5.4", platform = "linux"}
 lancedb = "^0.26.0"
+lance-namespace = "0.6.1"
 grapheme = "^0.6.0"
 pandas = "^3.0.2"
 


### PR DESCRIPTION
lance_namespace transitive dep released breaking version removing CreateEmptyTableRequest, which lancedb ^0.26.0 imports. Pin exact working version until poetry.lock is committed to repo.