### PR TITLE
whatsapp: fix audio-download failure due to failed tenant id lookup

### DIFF
--- a/byoeb-v1/byoeb/byoeb/services/chat/message_handlers/user_flow_handlers/process.py
+++ b/byoeb-v1/byoeb/byoeb/services/chat/message_handlers/user_flow_handlers/process.py
@@ -122,7 +122,16 @@ class ByoebUserProcess(Handler):
                     raise ValueError("media_info missing for audio message; cannot run speech-to-text")
                 media_id = media_info.media_id
                 with langfuse.start_as_current_observation(as_type="span", name="audio-download"):
-                    channel_client = await channel_client_factory.get(message.channel_type)
+                    from byoeb.services.auth.auth_service import get_auth_service
+                    from byoeb.services.chat import constants as chat_constants
+                    integration_id = (message.message_context.additional_info or {}).get(chat_constants.INTEGRATION_ID)
+                    if not integration_id:
+                        raise ValueError("integration_id missing from message additional_info; cannot download audio")
+                    auth_service = await get_auth_service()
+                    integrations = await auth_service.fetch_integrations([integration_id])
+                    if not integrations:
+                        raise ValueError(f"No integration found for integration_id={integration_id}")
+                    channel_client = await channel_client_factory.get(message.channel_type, integrations[0].identifier)
                     _, audio_message, err = await channel_client.adownload_media(media_id)
                 if err or audio_message is None:
                     raise RuntimeError("failed to download audio for speech-to-text")


### PR DESCRIPTION
Audio downloads are failing post-OWASP due to a missing integration lookup during the flow:
```
2026-04-27 17:48:15,654 ERROR byoeb.services.chat.message_consumer message_consumer.py 272 MainThread : [__process_byoebuser_conversation] ✖ error: ChannelClientFactory.get() missing 1 required positional argument: 'phone_number_id'
Traceback (most recent call last):
  File "/home/muqsit/a4i/byoeb-main/byoeb-v1/byoeb/byoeb/services/chat/message_consumer.py", line 256, in __process_byoebuser_conversation
    queries = await asyncio.wait_for(
              ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/asyncio/tasks.py", line 489, in wait_for
    return fut.result()
           ^^^^^^^^^^^^
  File "/home/muqsit/a4i/byoeb-main/byoeb-v1/byoeb/byoeb/services/chat/message_handlers/user_flow_handlers/process.py", line 208, in handle
    message = await self.handle_process_message_workflow(messages)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/muqsit/a4i/byoeb-main/byoeb-v1/byoeb/byoeb/services/chat/message_handlers/user_flow_handlers/process.py", line 159, in handle_process_message_workflow
    await self.annotate_audio_transcription(message)
  File "/home/muqsit/a4i/byoeb-main/byoeb-v1/byoeb/byoeb/services/chat/message_handlers/user_flow_handlers/process.py", line 125, in annotate_audio_transcription
    channel_client = await channel_client_factory.get(message.channel_type)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: ChannelClientFactory.get() missing 1 required positional argument: 'phone_number_id'
```

<details>
<summary>The following fix was tested by replaying an intercepted audio payload:</summary>

```
2026-04-27 17:50:50,855 INFO byoeb.listener.message_consumer message_consumer.py 175 MainThread : Received 1 messages
2026-04-27 17:50:50,856 INFO byoeb.services.chat.message_consumer message_consumer.py 306 MainThread : [consume] Processing 1 raw message(s)
2026-04-27 17:50:50,856 INFO byoeb.services.chat.message_consumer message_consumer.py 80 MainThread : [__create_conversations] ▶ start
2026-04-27 17:50:50,861 INFO byoeb.services.chat.message_consumer message_consumer.py 119 MainThread : [__create_conversations] user_found phone=********5304 user_type=asha reply_id=None
2026-04-27 17:50:50,865 create_conversations INFO: Creating conversation wamid.HBgMOTE2MzY0ODQ1MzA0FQIAEhggQUM3MEY0NzcyQ0YyQ0IyNDI4RkYxM0VCOEM3QjU1NjAD
2026-04-27 17:50:50,866 INFO byoeb.services.chat.message_consumer message_consumer.py 189 MainThread : [__create_conversations] no_bot_msg -> conversations (msg_id=wamid.HBgMOTE2MzY0ODQ1MzA0FQIAEhggQUM3MEY0NzcyQ0YyQ0IyNDI4RkYxM0VCOEM3QjU1NjAD)
2026-04-27 17:50:50,866 INFO byoeb.services.chat.message_consumer message_consumer.py 248 MainThread : [__create_conversations] ◀ end conversations=1 onboard=0 took=0.009s
2026-04-27 17:50:50,866 INFO byoeb.services.chat.message_consumer message_consumer.py 322 MainThread : [consume] conversations=1 onboard=0 create_time=0.010s
2026-04-27 17:50:50,867 INFO byoeb.services.chat.message_consumer message_consumer.py 252 MainThread : [__process_byoebuser_conversation] ▶ start msg_id=wamid.HBgMOTE2MzY0ODQ1MzA0FQIAEhggQUM3MEY0NzcyQ0YyQ0IyNDI4RkYxM0VCOEM3QjU1NjAD
2026-04-27 17:51:00,097 audio_to_text INFO: Time taken for audio to text transcribe: 9.228121 seconds
2026-04-27 17:51:00,099 INFO byoeb.services.chat.message_handlers.user_flow_handlers.process process.py 185 MainThread : [process] Processing normal message (not onboarding): 'One central injection....'
2026-04-27 17:51:01,814 query_rewriting INFO: Rewrote queries for wamid.HBgMOTE2MzY0ODQ1MzA0FQIAEhggQUM3MEY0NzcyQ0YyQ0IyNDI4RkYxM0VCOEM3QjU1NjAD in 1.714494 using 44 completion and 1266 prompt tokens
2026-04-27 17:51:01,816 INFO byoeb.services.chat.message_handlers.user_flow_handlers.generate generate.py 867 MainThread : [generate] Processing normal message (user_language=en)
2026-04-27 17:51:04,878 generate_answer_and_related_questions INFO: Generated related questions for wamid.HBgMOTE2MzY0ODQ1MzA0FQIAEhggQUM3MEY0NzcyQ0YyQ0IyNDI4RkYxM0VCOEM3QjU1NjAD in 3.061521363999418s
2026-04-27 17:51:07,036 text_to_audio INFO: Created audio response message in 2.156599724999978 seconds
2026-04-27 17:51:07,041 INFO byoeb.services.chat.message_handlers.user_flow_handlers.generate generate.py 960 MainThread : Created user message
2026-04-27 17:51:07,041 INFO byoeb.services.chat.message_handlers.user_flow_handlers.generate generate.py 986 MainThread : [GENERATE] Final byoeb_messages count: 2
2026-04-27 17:51:07,041 INFO byoeb.services.chat.message_handlers.user_flow_handlers.generate generate.py 1000 MainThread : [GENERATE] Generated 2 messages
2026-04-27 17:51:07,041 INFO byoeb.services.chat.message_handlers.user_flow_handlers.generate generate.py 1011 MainThread : [GENERATE] Passing 2 messages to successor
2026-04-27 17:51:07,042 INFO ByoebUserSendResponse send.py 208 MainThread : [send] __handle_message_send_workflow: start messages_count=2
2026-04-27 17:51:10,145 INFO ByoebUserSendResponse send.py 189 MainThread : User responses=[WhatsAppResponse(response_status=WhatsAppResponseStatus(status='200', error='None'), messaging_product='whatsapp', contacts=[Contact(input='916364845304', wa_id='916364845304')], messages=[Message(id='wamid.HBgMOTE2MzY0ODQ1MzA0FQIAERgSRDdDNUI4RjM4RTRGRTIxMTdEAA==', message_status=None)], media_message=None)]
2026-04-27 17:51:10,145 INFO ByoebUserSendResponse send.py 258 MainThread : [send] gather done; user_responses_len=1 expert_responses_len=0
2026-04-27 17:51:10,146 INFO ByoebUserSendResponse send.py 284 MainThread : [send] bot_to_user_convs_count=1
2026-04-27 17:51:10,146 message_send_workflow INFO: end_time=1777283470.146263 duration=3.1040749549865723
2026-04-27 17:51:10,146 INFO ByoebUserSendResponse send.py 303 MainThread : [send] returning from __handle_message_send_workflow
2026-04-27 17:51:10,149 INFO byoeb.services.chat.message_consumer message_consumer.py 260 MainThread : [__process_byoebuser_conversation] ◀ ok queries_count=2
2026-04-27 17:51:10,150 INFO byoeb.services.chat.message_consumer message_consumer.py 350 MainThread : [consume] tasks_done count=1
2026-04-27 17:51:10,150 INFO byoeb.services.chat.message_consumer message_consumer.py 358 MainThread : [consume] task_result ok msg_id=wamid.HBgMOTE2MzY0ODQ1MzA0FQIAEhggQUM3MEY0NzcyQ0YyQ0IyNDI4RkYxM0VCOEM3QjU1NjAD
2026-04-27 17:51:10,525 write_to_db INFO: Wrote message wamid.HBgMOTE2MzY0ODQ1MzA0FQIAEhggQUM3MEY0NzcyQ0YyQ0IyNDI4RkYxM0VCOEM3QjU1NjAD to database
2026-04-27 17:51:10,525 INFO byoeb.services.chat.message_consumer message_consumer.py 386 MainThread : [consume] ◀ end success_count=1
2026-04-27 17:51:10,525 INFO byoeb.listener.message_consumer message_consumer.py 181 MainThread : consume() returned 1 successfully processed messages
2026-04-27 17:51:10,526 INFO byoeb.listener.message_consumer message_consumer.py 183 MainThread : Successfully processed 1 messages
2026-04-27 17:51:10,674 INFO byoeb.listener.message_consumer message_consumer.py 195 MainThread : Deleted 1 messages
2026-04-27 17:51:10,674 batch_message_consumer INFO: Processed batch of 1 messages for queue botmessages in 19.81901 seconds
```
</details>